### PR TITLE
Refactor Box<dyn Plan> to Arc<dyn Plan> for shared ownership

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,4 +49,4 @@ There is a test suite which provides basic coverage to ensure the code still wor
    - Include what was implemented
    - Note any breaking changes
 
-6. **Address feedback as separate commits**)
+6. **Address feedback as separate commits**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# SimpleDB
+
+This documentation provides information about the SimpleDB project and also provides development workflow for Claude Code agents.
+
+## Project Overview
+
+**Purpose**: A simple SQL database which is a port of an existing SimpleDB database written in Java to Rust. It is mainly for pedagogical purposes and also as a way to experiment with Rust code and performance optimizations
+
+**Tech Stack**: Rust
+
+**Repository**: https://github.com/redixhumayun/simpledb
+
+## Architecture Overview
+
+Almost the entirety of the code can be found in `main.rs`. This is on purpose to keep the code in one place since this repo is for pedgagogical reasons.
+
+There are no dependencies apart from the Rust standard library and that is by design.
+
+The code is designed to construct and answer typical SQL queries. The code will construct a query tree that will use the pull-based iterator pattern in a way that is probably typical in most SQL systems. However, the code leans towards readability rather than performance.
+
+There is a test suite which provides basic coverage to ensure the code still works. This can be run with `cargo test`
+
+## Development Workflow
+
+### Git Workflow
+[1. ](### Git Workflow (REQUIRED)
+1. **Always start by syncing with master**:
+   ```bash
+   git checkout master
+   git pull origin master
+   ```
+
+2. **Create feature branch with descriptive name**:
+   ```bash
+   git checkout -b feature/descriptive-name
+   # or fix/bug-description, enhance/improvement-name
+   ```
+
+3. **Work autonomously using available tools** until blocked
+
+4. **Test thoroughly before committing**:
+   ```bash
+   cargo build
+   cargo test
+   # Verify build works and tests pass
+   ```
+
+5. **Create PR with descriptive title and summary**
+   - Include what was implemented
+   - Note any breaking changes
+
+6. **Address feedback as separate commits**)


### PR DESCRIPTION
## Summary
- Replace all `Box<dyn Plan>` usage with `Arc<dyn Plan>` to enable plan cloning for optimizer work
- Maintains thread safety while enabling shared ownership of plans
- Scan objects remain as `Box<dyn>` for safety since they contain mutable state

## Changes Made
- **Plan Structs**: Updated all plan struct fields from `Box<dyn Plan>` to `Arc<dyn Plan>`
- **Function Signatures**: Updated all plan-related function parameters and return types
- **Constructors**: Changed from `Box::new()` to `Arc::new()` for all plan object creation
- **Type Safety**: Plans can now be cloned using `Arc::clone(&plan)` for optimizer operations

## Test Plan
- [x] All 100 existing tests pass
- [x] Code compiles successfully with `cargo build`
- [x] No functional changes - purely a refactoring for better ownership semantics

## Breaking Changes
None - this is an internal refactoring that doesn't affect the public API.

🤖 Generated with [Claude Code](https://claude.ai/code)