### PR TITLE
[BISECT] Compiler warnings cleanup - commit 1/19

### DIFF
--- a/docs/compiler-warnings-cleanup.md
+++ b/docs/compiler-warnings-cleanup.md
@@ -1,0 +1,348 @@
+# Compiler Warnings Cleanup Plan
+
+**Status**: In Progress
+**Goal**: Eliminate all 118 compiler warnings by integrating unused code into the production system
+
+## Current Architecture
+
+### Query Execution Flow
+1. CLI (`src/bin/simpledb-cli.rs`) receives SQL
+2. `db.planner.create_query_plan()` for SELECT queries
+3. `db.planner.execute_update()` for DML operations
+4. Currently using:
+   - **Query Planner**: `BasicQueryPlanner` (simple product joins)
+   - **Update Planner**: `IndexUpdatePlanner`
+   - **BasicUpdatePlanner** is commented out (line 92 in main.rs)
+
+### Key Observation
+`BasicQueryPlanner` creates naive query plans:
+- Always uses `ProductPlan` for joins (Cartesian product)
+- No cost-based optimization
+- No alternative join strategies (merge join, index join)
+- No sorting capabilities
+
+Many advanced components exist but are unused outside tests.
+
+---
+
+## Phase 1: Major Components Integration
+
+### 1.1 Integrate HeuristicQueryPlanner ✅ PRIORITY
+
+**Status**: Pending
+**Complexity**: Medium
+**Impact**: High - enables cost-based optimization
+
+**Current State**:
+- `HeuristicQueryPlanner` exists at line 3898
+- Uses `TablePlanner` for cost-based physical optimization
+- Can choose between different join strategies
+- Only used in tests
+
+**Implementation**:
+- [ ] Make `HeuristicQueryPlanner` the default query planner in `SimpleDB::new()`
+- [ ] Replace line 91: `BasicQueryPlanner::new()` → `HeuristicQueryPlanner::new()`
+- [ ] Keep `BasicQueryPlanner` as fallback option
+- [ ] Test with existing queries to ensure compatibility
+- [ ] Verify performance improvement with benchmarks
+
+**Files to modify**:
+- `src/main.rs` line 91 (SimpleDB::new)
+
+**Testing**:
+```bash
+cargo build
+cargo test basic_query_planner_tests
+cargo test heuristic_query_planner_tests
+```
+
+---
+
+### 1.2 Integrate Alternative Join Strategies
+
+**Status**: Pending
+**Complexity**: High
+**Impact**: High - significant performance for large joins
+
+#### 1.2a MergeJoinPlan
+
+**Current State**:
+- Struct at line 1126
+- Requires sorted inputs
+- Only used in `merge_join_plan_tests`
+
+**Implementation**:
+- [ ] Integrate into `HeuristicQueryPlanner` or `TablePlanner`
+- [ ] Add logic to detect when inputs are sorted (via index or explicit sort)
+- [ ] Choose `MergeJoinPlan` when applicable
+- [ ] Benchmark against `ProductPlan`
+
+**Testing**:
+```bash
+cargo test merge_join_plan_tests
+```
+
+#### 1.2b IndexJoinPlan
+
+**Current State**:
+- Struct at line 5373
+- Uses index on right side for efficient lookup
+- Only used in tests
+
+**Implementation**:
+- [ ] Integrate into query planner
+- [ ] Detect when index exists on join column
+- [ ] Add cost estimation: index scan vs product
+- [ ] Choose `IndexJoinPlan` when cost-effective
+
+**Files to modify**:
+- `HeuristicQueryPlanner::get_lowest_join_plan()` (add index join option)
+- `TablePlanner` (add index join as candidate)
+
+---
+
+### 1.3 Integrate SortPlan for ORDER BY
+
+**Status**: Pending
+**Complexity**: Medium
+**Impact**: High - required for ORDER BY support
+
+**Current State**:
+- `SortPlan` exists at line 1927
+- External merge sort implementation
+- Only used in tests
+- CLI doesn't support ORDER BY syntax
+
+**Implementation**:
+- [ ] Extend SQL parser to support ORDER BY clause
+- [ ] Add `order_by: Vec<String>` to `QueryData` struct
+- [ ] Wrap final plan with `SortPlan` when ORDER BY present
+- [ ] Test with simple and complex queries
+
+**SQL Examples**:
+```sql
+SELECT * FROM students ORDER BY grade
+SELECT name, age FROM users ORDER BY age DESC
+```
+
+**Files to modify**:
+- Parser (add ORDER BY parsing)
+- `QueryData` struct
+- `Planner::create_query_plan()` or planners themselves
+
+**Testing**:
+```bash
+cargo test sort_plan_tests
+```
+
+---
+
+### 1.4 Integrate Hash Index
+
+**Status**: Pending
+**Complexity**: High
+**Impact**: Medium - alternative index type
+
+**Current State**:
+- `HashIndex` struct at line 7296
+- Constant NUM_BUCKETS
+- Never constructed
+
+**Implementation**:
+- [ ] Add CLI command: `CREATE INDEX idx_name ON table(field) USING HASH`
+- [ ] Extend index creation logic to support hash indexes
+- [ ] Integrate into index selection for equality predicates
+- [ ] Add cost estimation (hash vs btree)
+
+**Files to modify**:
+- Parser (extend CREATE INDEX)
+- Index creation logic
+- Query planner (index selection)
+
+---
+
+### 1.5 Enable BasicUpdatePlanner Option
+
+**Status**: Pending
+**Complexity**: Low
+**Impact**: Low - already have IndexUpdatePlanner
+
+**Current State**:
+- Line 92: `BasicUpdatePlanner` commented out
+- Using `IndexUpdatePlanner` instead
+
+**Implementation**:
+- [ ] Uncomment and enable as alternative
+- [ ] Add configuration option to choose update planner
+- [ ] Document differences between Basic vs Index update planner
+
+---
+
+## Phase 2: Smaller Items Integration
+
+### 2.1 Extend Predicate Support
+
+**Status**: Pending
+**Complexity**: Medium
+**Impact**: Medium - richer WHERE clauses
+
+**Unused Operators**:
+- `LessThanOrEqual` (<=)
+- `GreaterThanOrEqual` (>=)
+- `NotEqual` (!=)
+- Arithmetic: `Add`, `Subtract`, `Multiply`, `Divide`, `Modulo`
+
+**Implementation**:
+- [ ] Extend parser to recognize these operators
+- [ ] Add to predicate evaluation logic
+- [ ] Test with complex WHERE clauses
+
+**SQL Examples**:
+```sql
+SELECT * FROM users WHERE age >= 18
+SELECT * FROM products WHERE price <= 100 AND stock != 0
+SELECT * FROM orders WHERE total * tax > 1000
+```
+
+---
+
+### 2.2 Add Introspection/Debug Methods
+
+**Status**: ✅ COMPLETED
+**Complexity**: Low
+**Impact**: Low - developer experience
+
+**Unused Fields/Methods**:
+- Never-read fields: `db_directory`, `metadata_manager`, `table_schema`, etc.
+- Unused methods: `rollback()`, `recover()`, `available()`, `get_view_def()`
+
+**Implementation**:
+- [x] Add CLI command: `SHOW DATABASE` (uses db_directory)
+- [x] Add CLI command: `SHOW TABLES` (uses metadata_manager)
+- [x] Add CLI command: `SHOW BUFFERS` (uses buffer_manager.available())
+- [x] Made `available()` method public
+- [x] Made `MetadataManager` public
+- [x] Added `db_directory()` and `metadata_manager()` accessors to SimpleDB
+- [x] Added `get_table_names()` method to TableManager and MetadataManager
+- [ ] Add CLI command: `DESCRIBE table_name` (uses table_schema, stat_info)
+- [ ] Expose `rollback()` via CLI error handling
+- [ ] Document `recover()` for crash recovery
+
+**CLI Commands Added**:
+```
+simpledb> SHOW DATABASE
+simpledb> SHOW TABLES
+simpledb> SHOW BUFFERS
+```
+
+**Warnings Eliminated**: 3 (db_directory, metadata_manager, available())
+
+---
+
+### 2.3 Fix Unused Variables in Stubs
+
+**Status**: Pending
+**Complexity**: Trivial
+**Impact**: Low - just warning suppression
+
+**Locations**:
+- UpdateScan implementations with `unimplemented!()`
+- Parameters: `field_name`, `value`, `rid`, `e`, `op`, etc.
+
+**Implementation**:
+- [ ] Prefix all unused parameters with underscore: `_field_name`, `_value`, `_rid`
+- [ ] Standard Rust convention for required-but-unused parameters
+
+**Example**:
+```rust
+fn set_int(&self, _field_name: &str, _value: i32) -> Result<(), Box<dyn Error>> {
+    unimplemented!()
+}
+```
+
+---
+
+### 2.4 Address Test-Only Code
+
+**Status**: Pending
+**Complexity**: Low
+**Impact**: Low - understanding only
+
+**Components**:
+- `MultiBufferProductPlan/Scan` - only in tests
+- `ChunkScan` - only in tests
+- `RecordComparator` - only in tests
+- `TempTable` - only in tests (but MaterializePlan uses it!)
+
+**Analysis Needed**:
+- [ ] Verify if `TempTable` is actually used via `MaterializePlan`
+- [ ] Check if `MultiBufferProductPlan` should be production option
+- [ ] Document which components are test-only vs. should be integrated
+
+---
+
+### 2.5 Handle Orphaned main() Function
+
+**Status**: Pending
+**Complexity**: Trivial
+**Impact**: None
+
+**Location**: Line 11787
+
+**Current Code**:
+```rust
+fn main() {
+    let db = SimpleDB::new("random", 800, 4, true, 100);
+}
+```
+
+**Implementation**:
+- [ ] Remove if truly unused
+- [ ] Or move to test/example if it serves a purpose
+
+---
+
+## Success Criteria
+
+- [ ] Zero compiler warnings: `cargo build 2>&1 | grep warning` returns nothing
+- [ ] All tests pass: `cargo test`
+- [ ] Benchmarks run successfully: `cargo bench --bench buffer_pool -- 50 12`
+- [ ] No functional regressions in existing queries
+- [ ] New functionality documented in CLI help
+
+---
+
+## Progress Tracking
+
+### Completed
+- [x] Architecture exploration
+- [x] Plan documentation
+- [x] CLI introspection commands (SHOW DATABASE, SHOW TABLES, SHOW BUFFERS)
+- [x] Public accessors for previously unused fields (`db_directory`, `metadata_manager`, `available()`)
+- [x] `get_table_names()` implementation
+
+### Warning Count
+- **Started**: 118 warnings
+- **Current**: 115 warnings
+- **Eliminated**: 3 warnings
+
+### In Progress
+- [ ] Additional unused variable/field fixes
+- [ ] Remaining introspection commands (DESCRIBE table)
+
+### Next Steps
+1. ~~Add basic introspection commands~~ ✅
+2. Add DESCRIBE table command (uses stat_info, table_schema)
+3. Fix remaining unused variable warnings systematically
+4. Extend parser for additional operators (<=, >=, !=, arithmetic)
+5. Optionally integrate alternative query planners/join strategies
+
+---
+
+## Notes
+
+- Focus on **integration** over **suppression**
+- Code exists for a reason - make it usable
+- Test incrementally after each integration
+- Update this document as work progresses
+- Other agents can pick up sub-tasks from here


### PR DESCRIPTION
## Bisect Process - Finding Test Failure Root Cause

This PR applies commits from the compiler warnings cleanup one at a time to identify which commit causes `test_transaction_isolation_with_concurrent_writes` to fail in CI.

**Current commit:** 1/19
**Commit:** `cb05e86` - Add CLI introspection commands and expose unused fields

**Process:**
- Apply one commit at a time
- Wait for CI to pass/fail
- If pass, add next commit
- If fail, we've found the problematic commit

**Testing:** Watch CI results for test failures, specifically the concurrent writes test.