### PR TITLE
fix: release B-tree scan gate on EOF

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ There is a test suite which provides basic coverage to ensure the code still wor
 3. **Work autonomously using available tools** until blocked
 
 4. **Test thoroughly before committing**:
-   Testing requires running tests with combinations of compiler flags. Run these tests serially.
+   Testing requires running tests with combinations of compiler flags. Run these commands one after another; do not use `--test-threads=1`.
    ```bash
    cargo build
    cargo test --no-default-features --features replacement_lru --features page-4k

--- a/src/btree.rs
+++ b/src/btree.rs
@@ -1110,9 +1110,13 @@ impl Index for BTreeIndex {
             .read_cursor
             .as_mut()
             .expect("ReadCursor not initialized, did you forget to call before_first?");
-        cursor
+        let advanced = cursor
             .next(&self.txn, &self.leaf_layout, &self.index_file_name)
-            .expect("scan next failed")
+            .expect("scan next failed");
+        if !advanced {
+            self.scan_gate_guard = None;
+        }
+        advanced
     }
 
     fn get_data_rid(&self) -> RID {


### PR DESCRIPTION
## Summary

Follow-on to #88. That PR merged before the last review fixes on this branch landed.

This PR carries the remaining changes:
- release the shared scan gate as soon as a B-tree scan is exhausted instead of holding it until cursor teardown
- keep split-causing writers from being blocked longer than necessary after `next()` returns `false`
- fix the local AGENTS guidance to say test commands should be run one after another, not with `--test-threads=1`

## Why

In the current scan path, `BTreeIndex::next()` kept `scan_gate_guard` alive even after the cursor had reached EOF. That extends the lifetime of the shared split gate beyond the actual scan and can unnecessarily delay writers that need the exclusive gate for structural changes.
