### PR TITLE
focus io benchmarks on writeback behavior

### DIFF
--- a/benches/io_patterns.rs
+++ b/benches/io_patterns.rs
@@ -3,20 +3,13 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use simpledb::FileSystemInterface;
 use simpledb::{
-    direct_io_fallback_count, test_utils::generate_random_number, BatchReadReq, BlockId, Page,
-    SimpleDB, TestDir,
+    direct_io_fallback_count, test_utils::generate_random_number, BlockId, Page, SimpleDB, TestDir,
 };
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 type BenchFS = Arc<dyn FileSystemInterface + Send + Sync + 'static>;
 type Lsn = usize;
-
-// ============================================================================
-// WALFlushPolicy / DataSyncPolicy
-// ============================================================================
 
 #[derive(Clone, Debug)]
 enum WALFlushPolicy {
@@ -81,12 +74,15 @@ impl DataSyncPolicy {
     }
 }
 
-// ============================================================================
-// Setup helpers
-// ============================================================================
+fn num_buffers() -> usize {
+    std::env::var("SIMPLEDB_BENCH_BUFFERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(12)
+}
 
 fn setup_io_test() -> (SimpleDB, TestDir) {
-    SimpleDB::new_for_test(12, 5000)
+    SimpleDB::new_for_test(num_buffers(), 5000)
 }
 
 fn precreate_blocks(db: &SimpleDB, file: &str, count: usize) {
@@ -107,47 +103,11 @@ fn make_wal_record(size: usize) -> Vec<u8> {
     vec![0u8; size]
 }
 
-struct FastRng(u64);
-
-impl FastRng {
-    fn new() -> Self {
-        Self(generate_random_number() as u64 | 1)
-    }
-
-    fn next_u64(&mut self) -> u64 {
-        let mut x = self.0;
-        x ^= x << 13;
-        x ^= x >> 7;
-        x ^= x << 17;
-        self.0 = x;
-        x
-    }
-
-    fn next_range(&mut self, n: usize) -> usize {
-        (self.next_u64() as usize) % n
-    }
-}
-
 fn working_set_blocks() -> usize {
     std::env::var("SIMPLEDB_BENCH_WORKING_SET")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(1000)
-}
-
-/// CI config for fast in-memory / buffered-IO groups: 1s warmup, 5s measurement, 100 samples.
-/// Returns None outside CI, leaving Criterion defaults untouched.
-fn ci_fast() -> Option<(Duration, Duration, usize)> {
-    std::env::var("CI")
-        .ok()
-        .map(|_| (Duration::from_secs(1), Duration::from_secs(5), 100))
-}
-
-/// CI config for thread-contention groups: 2s warmup, 8s measurement, 20 samples.
-fn ci_contention() -> Option<(Duration, Duration, usize)> {
-    std::env::var("CI")
-        .ok()
-        .map(|_| (Duration::from_secs(2), Duration::from_secs(8), 20))
 }
 
 /// CI config for fsync/durability groups: 3s warmup, 15s measurement, 10 samples.
@@ -157,184 +117,20 @@ fn ci_fsync() -> Option<(Duration, Duration, usize)> {
         .map(|_| (Duration::from_secs(3), Duration::from_secs(15), 10))
 }
 
-#[cfg(target_os = "linux")]
-fn posix_fadvise_dontneed(path: &std::path::Path) {
-    use std::os::unix::io::AsRawFd;
-    if let Ok(f) = std::fs::OpenOptions::new().read(true).open(path) {
-        let _ = unsafe { libc::posix_fadvise(f.as_raw_fd(), 0, 0, libc::POSIX_FADV_DONTNEED) };
-    }
+fn touch_block(
+    txn: &Arc<simpledb::Transaction>,
+    file: &str,
+    block_num: usize,
+    value: i32,
+    log: &Arc<Mutex<simpledb::LogManager>>,
+) {
+    let block_id = BlockId::new(file.to_string(), block_num);
+    let ws = txn.write_session();
+    let mut guard = ws.pin_write_guard(&block_id).unwrap();
+    write_i32_at(guard.bytes_mut(), 60, value);
+    let lsn = log.lock().unwrap().append(make_wal_record(100)).unwrap();
+    guard.mark_modified(txn.id(), lsn);
 }
-
-// ============================================================================
-// Phase 1: Sequential vs Random I/O
-// ============================================================================
-
-fn bench_phase1_io(c: &mut Criterion) {
-    let ws = working_set_blocks();
-    let total_ops = ws.min(1000);
-
-    let mut group = c.benchmark_group("Phase1/IO Throughput");
-    if let Some((wu, mt, ss)) = ci_fast() {
-        group.warm_up_time(wu);
-        group.measurement_time(mt);
-        group.sample_size(ss);
-    }
-
-    // Sequential Read
-    {
-        let (db, _dir) = setup_io_test();
-        let file = format!("seqread_{ws}");
-        precreate_blocks(&db, &file, ws);
-
-        group.bench_function(format!("Sequential Read ({total_ops} ops)"), |b| {
-            b.iter(|| {
-                let mut page = Page::new();
-                for i in 0..total_ops {
-                    let block_id = BlockId::new(file.clone(), i % ws);
-                    db.file_manager.read(&block_id, &mut page);
-                }
-            })
-        });
-    }
-
-    // Sequential Write
-    {
-        let (db, _dir) = setup_io_test();
-        let file = format!("seqwrite_{ws}");
-        precreate_blocks(&db, &file, ws);
-
-        group.bench_function(format!("Sequential Write ({total_ops} ops)"), |b| {
-            b.iter(|| {
-                let mut page = Page::new();
-                for i in 0..total_ops {
-                    write_i32_at(page.bytes_mut(), 60, i as i32);
-                    let block_id = BlockId::new(file.clone(), i % ws);
-                    db.file_manager.write(&block_id, &page);
-                }
-            })
-        });
-    }
-
-    // Random Read
-    {
-        let (db, _dir) = setup_io_test();
-        let file = format!("randread_{ws}");
-        precreate_blocks(&db, &file, ws);
-        let mut rng = FastRng::new();
-
-        group.bench_function(format!("Random Read ({total_ops} ops)"), |b| {
-            b.iter(|| {
-                let indices: Vec<usize> = (0..total_ops).map(|_| rng.next_range(ws)).collect();
-                let mut page = Page::new();
-                for &idx in &indices {
-                    let block_id = BlockId::new(file.clone(), idx);
-                    db.file_manager.read(&block_id, &mut page);
-                }
-            })
-        });
-    }
-
-    // Random Write
-    {
-        let (db, _dir) = setup_io_test();
-        let file = format!("randwrite_{ws}");
-        precreate_blocks(&db, &file, ws);
-        let mut rng = FastRng::new();
-
-        group.bench_function(format!("Random Write ({total_ops} ops)"), |b| {
-            b.iter(|| {
-                let indices: Vec<usize> = (0..total_ops).map(|_| rng.next_range(ws)).collect();
-                let mut page = Page::new();
-                for (i, &idx) in indices.iter().enumerate() {
-                    write_i32_at(page.bytes_mut(), 60, i as i32);
-                    let block_id = BlockId::new(file.clone(), idx);
-                    db.file_manager.write(&block_id, &page);
-                }
-            })
-        });
-    }
-
-    group.finish();
-}
-
-// ============================================================================
-// Phase 1: Queue Depth variants
-// ============================================================================
-
-fn bench_phase1_qd(c: &mut Criterion) {
-    let ws = working_set_blocks();
-    let total_ops = ws.min(1000);
-
-    let mut group = c.benchmark_group("Phase1/Queue Depth");
-    if let Some((wu, mt, ss)) = ci_fast() {
-        group.warm_up_time(wu);
-        group.measurement_time(mt);
-        group.sample_size(ss);
-    }
-    group.throughput(Throughput::Elements(total_ops as u64));
-
-    for qd in [1usize, 16, 32] {
-        // Sequential Read QD
-        {
-            let (db, _dir) = setup_io_test();
-            let file = format!("seqread_qd{qd}_{ws}");
-            precreate_blocks(&db, &file, ws);
-
-            group.bench_with_input(BenchmarkId::new("Sequential Read QD", qd), &qd, |b, &qd| {
-                b.iter(|| {
-                    let mut done = 0usize;
-                    while done < total_ops {
-                        let n = (total_ops - done).min(qd.max(1));
-                        let mut reqs = Vec::with_capacity(n);
-                        let mut pages = Vec::with_capacity(n);
-                        for j in 0..n {
-                            reqs.push(BatchReadReq {
-                                block_id: BlockId::new(file.clone(), (done + j) % ws),
-                            });
-                            pages.push(Page::new());
-                        }
-                        db.file_manager.read_batch(&reqs, &mut pages);
-                        done += n;
-                    }
-                })
-            });
-        }
-
-        // Random Read QD
-        {
-            let (db, _dir) = setup_io_test();
-            let file = format!("randread_qd{qd}_{ws}");
-            precreate_blocks(&db, &file, ws);
-            let mut rng = FastRng::new();
-
-            group.bench_with_input(BenchmarkId::new("Random Read QD", qd), &qd, |b, &qd| {
-                b.iter(|| {
-                    let indices: Vec<usize> = (0..total_ops).map(|_| rng.next_range(ws)).collect();
-                    let mut done = 0usize;
-                    while done < total_ops {
-                        let n = (total_ops - done).min(qd.max(1));
-                        let mut reqs = Vec::with_capacity(n);
-                        let mut pages = Vec::with_capacity(n);
-                        for j in 0..n {
-                            reqs.push(BatchReadReq {
-                                block_id: BlockId::new(file.clone(), indices[done + j]),
-                            });
-                            pages.push(Page::new());
-                        }
-                        db.file_manager.read_batch(&reqs, &mut pages);
-                        done += n;
-                    }
-                })
-            });
-        }
-    }
-
-    group.finish();
-}
-
-// ============================================================================
-// Phase 2: WAL Performance
-// ============================================================================
 
 fn bench_wal(c: &mut Criterion) {
     let mut group = c.benchmark_group("Phase2/WAL");
@@ -344,7 +140,6 @@ fn bench_wal(c: &mut Criterion) {
         group.sample_size(ss);
     }
 
-    // WAL append no fsync (1000 ops)
     {
         let (db, _dir) = setup_io_test();
         let log = db.log_manager();
@@ -364,7 +159,6 @@ fn bench_wal(c: &mut Criterion) {
         });
     }
 
-    // WAL append immediate fsync (100 ops — fsync is slow)
     {
         let (db, _dir) = setup_io_test();
         let log = db.log_manager();
@@ -384,7 +178,6 @@ fn bench_wal(c: &mut Criterion) {
         });
     }
 
-    // WAL group commit (1000 ops, batch sizes 10/50/100)
     {
         let batch_size = 10usize;
         let (db, _dir) = setup_io_test();
@@ -416,158 +209,92 @@ fn bench_wal(c: &mut Criterion) {
     group.finish();
 }
 
-// ============================================================================
-// Phase 3: Mixed Read/Write Workloads
-// ============================================================================
-
-fn bench_mixed(c: &mut Criterion) {
-    let ws = working_set_blocks();
-    let mixed_ops = (ws / 2).clamp(1, 500);
-
-    let mut group = c.benchmark_group("Phase3/Mixed R/W");
+// Focus on writeback-heavy engine behavior rather than raw filesystem throughput.
+fn bench_writeback(c: &mut Criterion) {
+    let nb = num_buffers();
+    let ws = working_set_blocks().max(nb * 8);
+    let mut group = c.benchmark_group("Phase3/Writeback");
     if let Some((wu, mt, ss)) = ci_fsync() {
         group.warm_up_time(wu);
         group.measurement_time(mt);
         group.sample_size(ss);
     }
-    group.throughput(Throughput::Elements(mixed_ops as u64));
 
-    for read_pct in [70usize, 10] {
-        for (policy_template, policy_name) in [
-            (WALFlushPolicy::None, "no-fsync"),
-            (WALFlushPolicy::Immediate, "immediate-fsync"),
-            (
-                WALFlushPolicy::Group {
-                    batch: 10,
-                    pending: 0,
-                    last_lsn: None,
-                },
-                "group-10",
-            ),
-        ] {
-            let (db, _dir) = setup_io_test();
-            let file = format!("mixedfile_{ws}_{mixed_ops}");
-            precreate_blocks(&db, &file, ws);
-            let log = db.log_manager();
-            let mut rng = FastRng::new();
-            let policy = policy_template.clone();
+    {
+        let (db, _dir) = setup_io_test();
+        let file = format!("writeback_stream_{ws}_{nb}");
+        precreate_blocks(&db, &file, ws);
+        let log = db.log_manager();
+        let mut next_block = 0usize;
+        let pages_per_txn = nb.max(1);
 
-            group.bench_function(
-                format!("Mixed {read_pct}/{}/{policy_name}", 100 - read_pct),
-                |b| {
-                    b.iter(|| {
-                        let ops: Vec<bool> = (0..mixed_ops)
-                            .map(|_| rng.next_range(100) < read_pct)
-                            .collect();
-                        let block_indices: Vec<usize> =
-                            (0..mixed_ops).map(|_| rng.next_range(ws)).collect();
-                        let mut page = Page::new();
-                        let mut p = policy.clone();
+        group.throughput(Throughput::Elements(pages_per_txn as u64));
+        group.bench_function("stream fresh pages", |b| {
+            b.iter(|| {
+                let txn = db.new_tx();
+                for i in 0..pages_per_txn {
+                    let block_num = (next_block + i) % ws;
+                    touch_block(&txn, &file, block_num, (next_block + i) as i32, &log);
+                }
+                txn.write_session().commit().unwrap();
+                next_block = (next_block + pages_per_txn) % ws;
+            })
+        });
+    }
 
-                        for (i, &is_read) in ops.iter().enumerate() {
-                            let block_id = BlockId::new(file.clone(), block_indices[i]);
-                            if is_read {
-                                db.file_manager.read(&block_id, &mut page);
-                            } else {
-                                write_i32_at(page.bytes_mut(), 60, i as i32);
-                                db.file_manager.write(&block_id, &page);
-                                let record = make_wal_record(100);
-                                let lsn = log.lock().unwrap().append(record).unwrap();
-                                p.record(lsn, &log);
-                            }
-                        }
-                        p.finish_batch(&log);
-                    })
-                },
-            );
-            let _policy = policy;
-        }
+    {
+        let (db, _dir) = setup_io_test();
+        let file = format!("writeback_overfull_{ws}_{nb}");
+        precreate_blocks(&db, &file, ws * 2);
+        let log = db.log_manager();
+        let mut next_block = 0usize;
+        let pages_per_txn = (nb * 2).max(2);
+
+        group.throughput(Throughput::Elements(pages_per_txn as u64));
+        group.bench_function("overfull transaction", |b| {
+            b.iter(|| {
+                let txn = db.new_tx();
+                for i in 0..pages_per_txn {
+                    let block_num = (next_block + i) % (ws * 2);
+                    touch_block(&txn, &file, block_num, (next_block + i) as i32, &log);
+                }
+                txn.write_session().commit().unwrap();
+                next_block = (next_block + pages_per_txn) % (ws * 2);
+            })
+        });
+    }
+
+    {
+        let (db, _dir) = setup_io_test();
+        let file = format!("writeback_redirty_{ws}_{nb}");
+        precreate_blocks(&db, &file, ws * 2);
+        let log = db.log_manager();
+        let hot_pages = (nb / 4).max(1);
+        let cold_pages = nb.max(1);
+        let mut next_cold = hot_pages;
+
+        group.throughput(Throughput::Elements((hot_pages + cold_pages) as u64));
+        group.bench_function("hot re-dirty plus stream", |b| {
+            b.iter(|| {
+                let txn = db.new_tx();
+                for i in 0..hot_pages {
+                    touch_block(&txn, &file, i, generate_random_number() as i32, &log);
+                }
+                for i in 0..cold_pages {
+                    let block_num = next_cold + i;
+                    touch_block(&txn, &file, block_num % (ws * 2), (block_num) as i32, &log);
+                }
+                txn.write_session().commit().unwrap();
+                next_cold = (next_cold + cold_pages) % (ws * 2);
+                if next_cold < hot_pages {
+                    next_cold = hot_pages;
+                }
+            })
+        });
     }
 
     group.finish();
 }
-
-// ============================================================================
-// Phase 4: Concurrent I/O
-// ============================================================================
-
-fn bench_concurrent_io(c: &mut Criterion) {
-    let ws = working_set_blocks();
-    let concurrent_ops = ws.min(100);
-
-    let mut group = c.benchmark_group("Phase4/Concurrent IO");
-    if let Some((wu, mt, ss)) = ci_contention() {
-        group.warm_up_time(wu);
-        group.measurement_time(mt);
-        group.sample_size(ss);
-    }
-
-    for num_threads in [2usize, 4, 8, 16] {
-        for (policy_template, policy_name) in [
-            (WALFlushPolicy::None, "no-fsync"),
-            (
-                WALFlushPolicy::Group {
-                    batch: 10,
-                    pending: 0,
-                    last_lsn: None,
-                },
-                "group-10",
-            ),
-        ] {
-            // Shared file
-            {
-                let (db, _dir) = setup_io_test();
-                let file = "concurrent_shared".to_string();
-                let max_touchable = num_threads.saturating_mul(concurrent_ops).max(1);
-                let total_blocks = ws.min(max_touchable).max(1);
-                precreate_blocks(&db, &file, total_blocks);
-                let log = db.log_manager();
-                let policy_t = policy_template.clone();
-
-                group.throughput(Throughput::Elements((num_threads * concurrent_ops) as u64));
-                group.bench_function(format!("Shared {num_threads}T {policy_name}"), |b| {
-                    b.iter(|| {
-                        let handles: Vec<_> = (0..num_threads)
-                            .map(|_| {
-                                let file = file.clone();
-                                let log = Arc::clone(&log);
-                                let mut policy = policy_t.clone();
-                                let fm = Arc::clone(&db.file_manager);
-
-                                thread::spawn(move || {
-                                    let mut page = Page::new();
-                                    for i in 0..concurrent_ops {
-                                        let block_num = generate_random_number() % total_blocks;
-                                        let block_id = BlockId::new(file.clone(), block_num);
-                                        if (i % 10) < 7 {
-                                            fm.read(&block_id, &mut page);
-                                        } else {
-                                            write_i32_at(page.bytes_mut(), 60, i as i32);
-                                            fm.write(&block_id, &page);
-                                            let record = make_wal_record(100);
-                                            let lsn = log.lock().unwrap().append(record).unwrap();
-                                            policy.record(lsn, &log);
-                                        }
-                                    }
-                                    policy.finish_batch(&log);
-                                })
-                            })
-                            .collect();
-                        for h in handles {
-                            h.join().unwrap();
-                        }
-                    })
-                });
-            }
-        }
-    }
-
-    group.finish();
-}
-
-// ============================================================================
-// Phase 5: Random Write Durability
-// ============================================================================
 
 fn bench_durability(c: &mut Criterion) {
     let ws = working_set_blocks();
@@ -592,18 +319,16 @@ fn bench_durability(c: &mut Criterion) {
             let file = format!("randwrite_durable_{ws}_{durability_ops}");
             precreate_blocks(&db, &file, ws);
             let log = db.log_manager();
-            let mut rng = FastRng::new();
 
             group.bench_function(format!("{wal_name} {data_name}"), |b| {
                 b.iter(|| {
-                    let indices: Vec<usize> =
-                        (0..durability_ops).map(|_| rng.next_range(ws)).collect();
                     let mut page = Page::new();
                     let mut wp = wal_template.clone();
                     let mut dp = data_template.clone();
                     let fm = Arc::clone(&db.file_manager);
 
-                    for (i, &block_num) in indices.iter().enumerate() {
+                    for i in 0..durability_ops {
+                        let block_num = generate_random_number() % ws;
                         let block_id = BlockId::new(file.clone(), block_num);
                         write_i32_at(page.bytes_mut(), 60, i as i32);
                         fm.write(&block_id, &page);
@@ -621,219 +346,6 @@ fn bench_durability(c: &mut Criterion) {
     group.finish();
 }
 
-// ============================================================================
-// Phase 7: Cache-Adverse I/O Variants
-// ============================================================================
-
-fn bench_cache_adverse(c: &mut Criterion) {
-    let ws = working_set_blocks();
-
-    let mut group = c.benchmark_group("Phase7/Cache Adverse");
-    if let Some((wu, mt, ss)) = ci_fast() {
-        group.warm_up_time(wu);
-        group.measurement_time(mt);
-        group.sample_size(ss);
-    }
-
-    // One-pass sequential scan
-    {
-        let (db, _dir) = setup_io_test();
-        let file = format!("onepass_seq_{ws}");
-        precreate_blocks(&db, &file, ws);
-
-        group.bench_function(format!("One-pass Seq Scan ({ws} blocks)"), |b| {
-            b.iter(|| {
-                let mut page = Page::new();
-                for i in 0..ws {
-                    db.file_manager
-                        .read(&BlockId::new(file.clone(), i), &mut page);
-                }
-            })
-        });
-    }
-
-    // Low-locality random read
-    {
-        let (db, _dir) = setup_io_test();
-        let file = format!("lo_loc_rand_{ws}");
-        precreate_blocks(&db, &file, ws);
-        let mut rng = FastRng::new();
-
-        group.bench_function(format!("Low-locality Rand Read ({ws} blocks)"), |b| {
-            b.iter(|| {
-                let mut indices: Vec<usize> = (0..ws).collect();
-                for i in (1..ws).rev() {
-                    let j = rng.next_range(i + 1);
-                    indices.swap(i, j);
-                }
-                let mut page = Page::new();
-                for &idx in &indices {
-                    db.file_manager
-                        .read(&BlockId::new(file.clone(), idx), &mut page);
-                }
-            })
-        });
-    }
-
-    // Multi-stream scan
-    {
-        let num_streams = 4usize;
-        let (db, _dir) = setup_io_test();
-        let blocks_per_stream = (ws / num_streams).max(1);
-        for s in 0..num_streams {
-            let f = format!("multi_stream_{num_streams}_{s}");
-            precreate_blocks(&db, &f, blocks_per_stream);
-        }
-
-        group.bench_function(format!("Multi-stream Scan ({ws} blocks)"), |b| {
-            b.iter(|| {
-                let handles: Vec<_> = (0..num_streams)
-                    .map(|s| {
-                        let file = format!("multi_stream_{num_streams}_{s}");
-                        let fm = Arc::clone(&db.file_manager);
-                        thread::spawn(move || {
-                            let mut page = Page::new();
-                            for i in 0..blocks_per_stream {
-                                fm.read(&BlockId::new(file.clone(), i), &mut page);
-                            }
-                        })
-                    })
-                    .collect();
-                for h in handles {
-                    h.join().unwrap();
-                }
-            })
-        });
-    }
-
-    group.finish();
-}
-
-// ============================================================================
-// Phase 8: Cache-Evict Variants (Linux only)
-// ============================================================================
-
-#[cfg(target_os = "linux")]
-fn bench_cache_evict(c: &mut Criterion) {
-    let ws = working_set_blocks();
-
-    let mut group = c.benchmark_group("Phase8/Cache Evict");
-    if let Some((wu, mt, ss)) = ci_fsync() {
-        group.warm_up_time(wu);
-        group.measurement_time(mt);
-        group.sample_size(ss);
-    }
-
-    // One-pass sequential scan + evict
-    {
-        let (db, test_dir) = setup_io_test();
-        let file_name = format!("onepass_seq_evict_{ws}");
-        let file_path: PathBuf = test_dir.path.join(&file_name);
-        precreate_blocks(&db, &file_name, ws);
-
-        group.bench_function(format!("One-pass Seq Scan+Evict ({ws} blocks)"), |b| {
-            b.iter_custom(|iters| {
-                let mut total = Duration::ZERO;
-                for _ in 0..iters {
-                    let t = Instant::now();
-                    let mut page = Page::new();
-                    for i in 0..ws {
-                        db.file_manager
-                            .read(&BlockId::new(file_name.clone(), i), &mut page);
-                    }
-                    total += t.elapsed();
-                    posix_fadvise_dontneed(&file_path);
-                }
-                total
-            })
-        });
-    }
-
-    // Low-locality random read + evict
-    {
-        let (db, test_dir) = setup_io_test();
-        let file_name = format!("lo_loc_rand_evict_{ws}");
-        let file_path: PathBuf = test_dir.path.join(&file_name);
-        precreate_blocks(&db, &file_name, ws);
-        let mut rng = FastRng::new();
-
-        group.bench_function(format!("Low-locality Rand Read+Evict ({ws} blocks)"), |b| {
-            b.iter_custom(|iters| {
-                let mut total = Duration::ZERO;
-                for _ in 0..iters {
-                    let mut indices: Vec<usize> = (0..ws).collect();
-                    for i in (1..ws).rev() {
-                        let j = rng.next_range(i + 1);
-                        indices.swap(i, j);
-                    }
-                    let t = Instant::now();
-                    let mut page = Page::new();
-                    for &idx in &indices {
-                        db.file_manager
-                            .read(&BlockId::new(file_name.clone(), idx), &mut page);
-                    }
-                    total += t.elapsed();
-                    posix_fadvise_dontneed(&file_path);
-                }
-                total
-            })
-        });
-    }
-
-    // Multi-stream scan + evict
-    {
-        let num_streams = 4usize;
-        let (db, test_dir) = setup_io_test();
-        let blocks_per_stream = (ws / num_streams).max(1);
-        let file_names: Vec<String> = (0..num_streams)
-            .map(|s| format!("multi_stream_evict_{num_streams}_{s}"))
-            .collect();
-        let file_paths: Vec<PathBuf> = file_names.iter().map(|f| test_dir.path.join(f)).collect();
-        for name in &file_names {
-            precreate_blocks(&db, name, blocks_per_stream);
-        }
-
-        group.bench_function(format!("Multi-stream Scan+Evict ({ws} blocks)"), |b| {
-            b.iter_custom(|iters| {
-                let mut total = Duration::ZERO;
-                for _ in 0..iters {
-                    let t = Instant::now();
-                    let handles: Vec<_> = file_names
-                        .iter()
-                        .map(|name| {
-                            let name = name.clone();
-                            let fm = Arc::clone(&db.file_manager);
-                            thread::spawn(move || {
-                                let mut page = Page::new();
-                                for i in 0..blocks_per_stream {
-                                    fm.read(&BlockId::new(name.clone(), i), &mut page);
-                                }
-                            })
-                        })
-                        .collect();
-                    for h in handles {
-                        h.join().unwrap();
-                    }
-                    total += t.elapsed();
-                    for path in &file_paths {
-                        posix_fadvise_dontneed(path);
-                    }
-                }
-                total
-            })
-        });
-    }
-
-    group.finish();
-}
-
-#[cfg(not(target_os = "linux"))]
-fn bench_cache_evict(_c: &mut Criterion) {}
-
-// ============================================================================
-// Direct I/O fallback reporting (attached to io_patterns for visibility)
-// ============================================================================
-
 fn report_direct_io(_c: &mut Criterion) {
     let fallbacks = direct_io_fallback_count();
     if cfg!(feature = "direct-io") && fallbacks > 0 {
@@ -846,14 +358,9 @@ fn report_direct_io(_c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    bench_phase1_io,
-    bench_phase1_qd,
     bench_wal,
-    bench_mixed,
-    bench_concurrent_io,
+    bench_writeback,
     bench_durability,
-    bench_cache_adverse,
-    bench_cache_evict,
     report_direct_io,
 );
 criterion_main!(benches);

--- a/benches/io_patterns.rs
+++ b/benches/io_patterns.rs
@@ -78,6 +78,7 @@ fn num_buffers() -> usize {
     std::env::var("SIMPLEDB_BENCH_BUFFERS")
         .ok()
         .and_then(|s| s.parse().ok())
+        .map(|n: usize| n.max(1))
         .unwrap_or(12)
 }
 
@@ -271,7 +272,8 @@ fn bench_writeback(c: &mut Criterion) {
         let log = db.log_manager();
         let hot_pages = (nb / 4).max(1);
         let cold_pages = nb.max(1);
-        let mut next_cold = hot_pages;
+        let cold_span = (ws * 2).saturating_sub(hot_pages).max(1);
+        let mut next_cold = 0usize;
 
         group.throughput(Throughput::Elements((hot_pages + cold_pages) as u64));
         group.bench_function("hot re-dirty plus stream", |b| {
@@ -281,14 +283,11 @@ fn bench_writeback(c: &mut Criterion) {
                     touch_block(&txn, &file, i, generate_random_number() as i32, &log);
                 }
                 for i in 0..cold_pages {
-                    let block_num = next_cold + i;
-                    touch_block(&txn, &file, block_num % (ws * 2), (block_num) as i32, &log);
+                    let block_num = hot_pages + ((next_cold + i) % cold_span);
+                    touch_block(&txn, &file, block_num, block_num as i32, &log);
                 }
                 txn.write_session().commit().unwrap();
-                next_cold = (next_cold + cold_pages) % (ws * 2);
-                if next_cold < hot_pages {
-                    next_cold = hot_pages;
-                }
+                next_cold = (next_cold + cold_pages) % cold_span;
             })
         });
     }


### PR DESCRIPTION
This trims `benches/io_patterns.rs` down to the benchmark groups that are most useful for the upcoming direct-I/O flush work. The old file mixed raw filesystem throughput, queue-depth, cache-adverse, and cache-eviction microbenches into the same suite, which made it harder to use as a stable reference for engine changes. The remaining groups keep WAL and durability coverage while removing the lower-signal buffered/cache-oriented cases.

In their place, this adds a focused writeback benchmark family built around real transaction/write-guard paths. The new cases cover streaming fresh-page writes, overfull transactions that exceed the buffer pool, and hot-page re-dirtying mixed with cold-page churn. Those scenarios are intended to give us a stable direct-I/O baseline on `master` before changing the flush protocol, so later comparisons stay about engine writeback behavior rather than about page-cache effects.