### PR TITLE
Add ORDER BY support to SELECT queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This documentation provides information about the SimpleDB project and also prov
 
 ## Project Overview
 
-**Purpose**: A simple SQL database which is a port of an existing SimpleDB database written in Java to Rust. It is mainly for pedagogical purposes and also as a way to experiment with Rust code and performance optimizations
+**Purpose**: A SQL database which started as a port of SimpleDB from Java to Rust. It is mainly a playground for performance profiling, testing and experimenting with novel approaches of building database engines.
 
 **Tech Stack**: Rust, Python
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,20 +46,17 @@ There is a test suite which provides basic coverage to ensure the code still wor
    - keep docs clear and concise; do not write verbose commentary
 
 5. **Test thoroughly before committing**:
-   Testing requires running tests with combinations of compiler flags. Run these commands one after another; do not use `--test-threads=1`.
+   Testing requires running tests with combinations of compiler flags. Direct-IO is the default IO path and must be included in every run. Run these commands one after another; do not use `--test-threads=1`.
    ```bash
    cargo build
-   cargo test --no-default-features --features replacement_lru --features page-4k
-   # Verify build works and tests pass
-
-   cargo test --no-default-features --features replacement_clock --features page-4k
-   # Verify build works and tests pass
-
-   cargo test --no-default-features --features replacement_sieve --features page-4k
-   # Verify build works and tests pass
-
    cargo test --no-default-features --features replacement_lru --features page-4k --features direct-io
-   # Verify direct-io build works and tests pass
+   # Verify build works and tests pass
+
+   cargo test --no-default-features --features replacement_clock --features page-4k --features direct-io
+   # Verify build works and tests pass
+
+   cargo test --no-default-features --features replacement_sieve --features page-4k --features direct-io
+   # Verify build works and tests pass
    ```
 
 6. **Run benchmarks before committing only when asked**

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ pub use btree::BTreeIndex;
 pub use btree::SplitGate;
 use parser::{
     CreateIndexData, CreateTableData, CreateViewData, DeleteData, InsertData, ModifyData, Parser,
-    QueryData,
+    QueryData, SortDirection,
 };
 
 pub use test_utils::TestDir;
@@ -2245,6 +2245,19 @@ impl SortPlan {
         }
     }
 
+    pub fn with_directions(
+        source_plan: Arc<dyn Plan>,
+        field_list: Vec<(String, SortDirection)>,
+    ) -> Self {
+        let schema = source_plan.schema();
+        let record_comparator = RecordComparator::with_directions(field_list);
+        Self {
+            source_plan,
+            schema,
+            record_comparator,
+        }
+    }
+
     pub fn open_sort_scan(&self, ctx: &ExecutionContext) -> SortScan {
         let source_scan = self.source_plan.open(ctx);
         let executor = SortExecutor::new(self.schema.clone(), self.record_comparator.clone());
@@ -2853,21 +2866,34 @@ mod sort_scan_tests {
 
 #[derive(Clone)]
 pub struct RecordComparator {
-    field_list: Vec<String>,
+    field_list: Vec<(String, SortDirection)>,
 }
 
 impl RecordComparator {
-    pub fn new(field_list: Vec<String>) -> Self {
+    /// Creates a comparator that sorts all fields ascending.
+    pub fn new(fields: Vec<String>) -> Self {
+        Self {
+            field_list: fields
+                .into_iter()
+                .map(|f| (f, SortDirection::Asc))
+                .collect(),
+        }
+    }
+
+    pub fn with_directions(field_list: Vec<(String, SortDirection)>) -> Self {
         Self { field_list }
     }
 
     fn compare<S1: Scan, S2: Scan>(&self, s1: &S1, s2: &S2) -> Result<Ordering, Box<dyn Error>> {
-        for field in &self.field_list {
+        for (field, dir) in &self.field_list {
             let value_1 = s1.get_value(field)?;
             let value_2 = s2.get_value(field)?;
             let cmp = value_1.cmp(&value_2);
             if cmp != std::cmp::Ordering::Equal {
-                return Ok(cmp);
+                return Ok(match dir {
+                    SortDirection::Asc => cmp,
+                    SortDirection::Desc => cmp.reverse(),
+                });
             }
         }
         Ok(Ordering::Equal)
@@ -4092,6 +4118,8 @@ impl HeuristicQueryPlanner {
         query_data: QueryData,
         ctx: &PlanningContext,
     ) -> SimpleDBResult<Arc<dyn Plan>> {
+        let order_by = query_data.order_by;
+
         //  Construct all instances of [TablePlanner]
         for table_name in query_data.tables {
             let table_planner =
@@ -4117,10 +4145,16 @@ impl HeuristicQueryPlanner {
             }
         }
 
-        Ok(Arc::new(ProjectPlan::new(
+        let mut plan: Arc<dyn Plan> = Arc::new(ProjectPlan::new(
             current_plan,
             query_data.fields.iter().map(String::as_str).collect(),
-        )?))
+        )?);
+
+        if !order_by.is_empty() {
+            plan = Arc::new(SortPlan::with_directions(plan, order_by));
+        }
+
+        Ok(plan)
     }
 
     /// Find the [SelectPlan] with the lowest record output
@@ -4214,6 +4248,7 @@ impl QueryPlanner for BasicQueryPlanner {
     /// 2. Create a join of all tables
     /// 3. Create a selection with the predicate
     /// 4. Create a projection of the required columns
+    /// 5. If ORDER BY is present, wrap with SortPlan
     fn create_plan(
         &self,
         query_data: QueryData,
@@ -4241,6 +4276,12 @@ impl QueryPlanner for BasicQueryPlanner {
             plan,
             query_data.fields.iter().map(AsRef::as_ref).collect(),
         )?);
+
+        //  5. Sort if ORDER BY was specified
+        if !query_data.order_by.is_empty() {
+            plan = Arc::new(SortPlan::with_directions(plan, query_data.order_by));
+        }
+
         Ok(plan)
     }
 }
@@ -4417,6 +4458,130 @@ mod basic_query_planner_tests {
             vec![
                 vec![Constant::String("y".into())],
                 vec![Constant::String("z".into())]
+            ]
+        );
+    }
+
+    #[test]
+    fn order_by_asc() {
+        let (db, txn, _dir) = setup_db();
+        let planner = basic_planner(&db);
+
+        exec(
+            &planner,
+            Arc::clone(&txn),
+            "create table t(a int, b varchar(10))",
+        );
+        for (a, b) in [(3, "c"), (1, "a"), (2, "b")] {
+            exec(
+                &planner,
+                Arc::clone(&txn),
+                &format!("insert into t(a,b) values ({a},'{b}')"),
+            );
+        }
+
+        let plan = planner
+            .create_query_plan(
+                "select a, b from t order by a asc".to_string(),
+                Arc::clone(&txn),
+            )
+            .unwrap();
+        let ctx = ExecutionContext::new(Arc::clone(&txn));
+        let mut scan = plan.open(&ctx);
+        scan.before_first().unwrap();
+        let mut rows = Vec::new();
+        while let Some(Ok(())) = scan.next() {
+            rows.push((scan.get_value("a").unwrap(), scan.get_value("b").unwrap()));
+        }
+        assert_eq!(
+            rows,
+            vec![
+                (Constant::Int(1), Constant::String("a".into())),
+                (Constant::Int(2), Constant::String("b".into())),
+                (Constant::Int(3), Constant::String("c".into())),
+            ]
+        );
+    }
+
+    #[test]
+    fn order_by_desc() {
+        let (db, txn, _dir) = setup_db();
+        let planner = basic_planner(&db);
+
+        exec(
+            &planner,
+            Arc::clone(&txn),
+            "create table t(a int, b varchar(10))",
+        );
+        for (a, b) in [(3, "c"), (1, "a"), (2, "b")] {
+            exec(
+                &planner,
+                Arc::clone(&txn),
+                &format!("insert into t(a,b) values ({a},'{b}')"),
+            );
+        }
+
+        let plan = planner
+            .create_query_plan(
+                "select a, b from t order by a desc".to_string(),
+                Arc::clone(&txn),
+            )
+            .unwrap();
+        let ctx = ExecutionContext::new(Arc::clone(&txn));
+        let mut scan = plan.open(&ctx);
+        scan.before_first().unwrap();
+        let mut rows = Vec::new();
+        while let Some(Ok(())) = scan.next() {
+            rows.push((scan.get_value("a").unwrap(), scan.get_value("b").unwrap()));
+        }
+        assert_eq!(
+            rows,
+            vec![
+                (Constant::Int(3), Constant::String("c".into())),
+                (Constant::Int(2), Constant::String("b".into())),
+                (Constant::Int(1), Constant::String("a".into())),
+            ]
+        );
+    }
+
+    #[test]
+    fn order_by_multi_column() {
+        let (db, txn, _dir) = setup_db();
+        let planner = basic_planner(&db);
+
+        exec(
+            &planner,
+            Arc::clone(&txn),
+            "create table t(a int, b varchar(10))",
+        );
+        for (a, b) in [(1, "z"), (2, "a"), (1, "a"), (2, "z")] {
+            exec(
+                &planner,
+                Arc::clone(&txn),
+                &format!("insert into t(a,b) values ({a},'{b}')"),
+            );
+        }
+
+        let plan = planner
+            .create_query_plan(
+                "select a, b from t order by a asc, b desc".to_string(),
+                Arc::clone(&txn),
+            )
+            .unwrap();
+        let ctx = ExecutionContext::new(Arc::clone(&txn));
+        let mut scan = plan.open(&ctx);
+        scan.before_first().unwrap();
+        let mut rows = Vec::new();
+        while let Some(Ok(())) = scan.next() {
+            rows.push((scan.get_value("a").unwrap(), scan.get_value("b").unwrap()));
+        }
+        assert_eq!(
+            rows,
+            vec![
+                (Constant::Int(1), Constant::String("z".into())),
+                (Constant::Int(1), Constant::String("a".into())),
+                (Constant::Int(2), Constant::String("z".into())),
+                (Constant::Int(2), Constant::String("a".into())),
             ]
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4146,7 +4146,7 @@ impl HeuristicQueryPlanner {
         }
 
         //  Sort before projection so ORDER BY can reference non-projected columns
-        let pre_project: Arc<dyn Plan> = if !order_by.is_empty() {
+        let pre_project = if !order_by.is_empty() {
             Arc::new(SortPlan::with_directions(current_plan, order_by))
         } else {
             current_plan
@@ -5501,19 +5501,20 @@ impl QueryPlanner for PipelineQueryPlanner {
         let logical = BasicLogicalPlanner::new().build(query_data, &ctx)?;
         let optimized = HeuristicLogicalOptimizer::new().optimize(logical, &ctx)?;
 
+        // BasicLogicalPlanner always produces a Project at the top of the tree.
+        assert_eq!(optimized.kind(), LogicalPlanKind::Project);
+
+        let input = optimized.input().unwrap();
+        let fields = optimized.project_fields().unwrap();
+        let mut plan = DefaultPhysicalPlanner::new().lower(input, &ctx)?;
+
         // Sort before projection so ORDER BY can reference non-projected columns.
-        // The optimized top node is always Project for a SELECT, so we lower the
-        // Project's input, wrap with SortPlan, then apply ProjectPlan on top.
-        if !order_by.is_empty() && optimized.kind() == LogicalPlanKind::Project {
-            let input = optimized.input().unwrap();
-            let fields = optimized.project_fields().unwrap();
-            let lowered = DefaultPhysicalPlanner::new().lower(input, &ctx)?;
-            let sorted: Arc<dyn Plan> = Arc::new(SortPlan::with_directions(lowered, order_by));
-            let field_refs: Vec<&str> = fields.iter().map(String::as_str).collect();
-            return Ok(Arc::new(ProjectPlan::new(sorted, field_refs)?));
+        if !order_by.is_empty() {
+            plan = Arc::new(SortPlan::with_directions(plan, order_by));
         }
 
-        DefaultPhysicalPlanner::new().lower(&optimized, &ctx)
+        let field_refs: Vec<&str> = fields.iter().map(String::as_str).collect();
+        Ok(Arc::new(ProjectPlan::new(plan, field_refs)?))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4753,6 +4753,80 @@ mod heuristic_equivalence_tests {
             &["name", "dept"],
         );
     }
+
+    #[test]
+    fn pipeline_planner_order_by_asc() {
+        let (db, txn, _dir) = setup_db();
+        let p = heuristic_planner(&db);
+
+        exec(&p, Arc::clone(&txn), "create table t(a int, b varchar(10))");
+        for (a, b) in [(3, "c"), (1, "a"), (2, "b")] {
+            exec(
+                &p,
+                Arc::clone(&txn),
+                &format!("insert into t(a,b) values ({a},'{b}')"),
+            );
+        }
+
+        let plan = p
+            .create_query_plan(
+                "select a, b from t order by a asc".to_string(),
+                Arc::clone(&txn),
+            )
+            .unwrap();
+        let ctx = ExecutionContext::new(Arc::clone(&txn));
+        let mut scan = plan.open(&ctx);
+        scan.before_first().unwrap();
+        let mut rows = Vec::new();
+        while let Some(Ok(())) = scan.next() {
+            rows.push((scan.get_value("a").unwrap(), scan.get_value("b").unwrap()));
+        }
+        assert_eq!(
+            rows,
+            vec![
+                (Constant::Int(1), Constant::String("a".into())),
+                (Constant::Int(2), Constant::String("b".into())),
+                (Constant::Int(3), Constant::String("c".into())),
+            ]
+        );
+    }
+
+    #[test]
+    fn pipeline_planner_order_by_desc() {
+        let (db, txn, _dir) = setup_db();
+        let p = heuristic_planner(&db);
+
+        exec(&p, Arc::clone(&txn), "create table t(a int, b varchar(10))");
+        for (a, b) in [(3, "c"), (1, "a"), (2, "b")] {
+            exec(
+                &p,
+                Arc::clone(&txn),
+                &format!("insert into t(a,b) values ({a},'{b}')"),
+            );
+        }
+
+        let plan = p
+            .create_query_plan(
+                "select a, b from t order by b desc".to_string(),
+                Arc::clone(&txn),
+            )
+            .unwrap();
+        let ctx = ExecutionContext::new(Arc::clone(&txn));
+        let mut scan = plan.open(&ctx);
+        scan.before_first().unwrap();
+        let mut rows = Vec::new();
+        while let Some(Ok(())) = scan.next() {
+            rows.push((scan.get_value("a").unwrap(), scan.get_value("b").unwrap()));
+        }
+        assert_eq!(
+            rows,
+            vec![
+                (Constant::Int(3), Constant::String("c".into())),
+                (Constant::Int(2), Constant::String("b".into())),
+                (Constant::Int(1), Constant::String("a".into())),
+            ]
+        );
+    }
 }
 
 #[cfg(test)]
@@ -5533,9 +5607,14 @@ impl QueryPlanner for PipelineQueryPlanner {
         txn: Arc<Transaction>,
     ) -> SimpleDBResult<Arc<dyn Plan>> {
         let ctx = PlanningContext::new(txn, Arc::clone(&self.metadata_manager));
+        let order_by = query_data.order_by.clone();
         let logical = BasicLogicalPlanner::new().build(query_data, &ctx)?;
         let optimized = HeuristicLogicalOptimizer::new().optimize(logical, &ctx)?;
-        DefaultPhysicalPlanner::new().lower(&optimized, &ctx)
+        let mut plan = DefaultPhysicalPlanner::new().lower(&optimized, &ctx)?;
+        if !order_by.is_empty() {
+            plan = Arc::new(SortPlan::with_directions(plan, order_by));
+        }
+        Ok(plan)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4462,170 +4462,6 @@ mod basic_query_planner_tests {
             ]
         );
     }
-
-    #[test]
-    fn order_by_asc() {
-        let (db, txn, _dir) = setup_db();
-        let planner = basic_planner(&db);
-
-        exec(
-            &planner,
-            Arc::clone(&txn),
-            "create table t(a int, b varchar(10))",
-        );
-        for (a, b) in [(3, "c"), (1, "a"), (2, "b")] {
-            exec(
-                &planner,
-                Arc::clone(&txn),
-                &format!("insert into t(a,b) values ({a},'{b}')"),
-            );
-        }
-
-        let plan = planner
-            .create_query_plan(
-                "select a, b from t order by a asc".to_string(),
-                Arc::clone(&txn),
-            )
-            .unwrap();
-        let ctx = ExecutionContext::new(Arc::clone(&txn));
-        let mut scan = plan.open(&ctx);
-        scan.before_first().unwrap();
-        let mut rows = Vec::new();
-        while let Some(Ok(())) = scan.next() {
-            rows.push((scan.get_value("a").unwrap(), scan.get_value("b").unwrap()));
-        }
-        assert_eq!(
-            rows,
-            vec![
-                (Constant::Int(1), Constant::String("a".into())),
-                (Constant::Int(2), Constant::String("b".into())),
-                (Constant::Int(3), Constant::String("c".into())),
-            ]
-        );
-    }
-
-    #[test]
-    fn order_by_desc() {
-        let (db, txn, _dir) = setup_db();
-        let planner = basic_planner(&db);
-
-        exec(
-            &planner,
-            Arc::clone(&txn),
-            "create table t(a int, b varchar(10))",
-        );
-        for (a, b) in [(3, "c"), (1, "a"), (2, "b")] {
-            exec(
-                &planner,
-                Arc::clone(&txn),
-                &format!("insert into t(a,b) values ({a},'{b}')"),
-            );
-        }
-
-        let plan = planner
-            .create_query_plan(
-                "select a, b from t order by a desc".to_string(),
-                Arc::clone(&txn),
-            )
-            .unwrap();
-        let ctx = ExecutionContext::new(Arc::clone(&txn));
-        let mut scan = plan.open(&ctx);
-        scan.before_first().unwrap();
-        let mut rows = Vec::new();
-        while let Some(Ok(())) = scan.next() {
-            rows.push((scan.get_value("a").unwrap(), scan.get_value("b").unwrap()));
-        }
-        assert_eq!(
-            rows,
-            vec![
-                (Constant::Int(3), Constant::String("c".into())),
-                (Constant::Int(2), Constant::String("b".into())),
-                (Constant::Int(1), Constant::String("a".into())),
-            ]
-        );
-    }
-
-    #[test]
-    fn order_by_multi_column() {
-        let (db, txn, _dir) = setup_db();
-        let planner = basic_planner(&db);
-
-        exec(
-            &planner,
-            Arc::clone(&txn),
-            "create table t(a int, b varchar(10))",
-        );
-        for (a, b) in [(1, "z"), (2, "a"), (1, "a"), (2, "z")] {
-            exec(
-                &planner,
-                Arc::clone(&txn),
-                &format!("insert into t(a,b) values ({a},'{b}')"),
-            );
-        }
-
-        let plan = planner
-            .create_query_plan(
-                "select a, b from t order by a asc, b desc".to_string(),
-                Arc::clone(&txn),
-            )
-            .unwrap();
-        let ctx = ExecutionContext::new(Arc::clone(&txn));
-        let mut scan = plan.open(&ctx);
-        scan.before_first().unwrap();
-        let mut rows = Vec::new();
-        while let Some(Ok(())) = scan.next() {
-            rows.push((scan.get_value("a").unwrap(), scan.get_value("b").unwrap()));
-        }
-        assert_eq!(
-            rows,
-            vec![
-                (Constant::Int(1), Constant::String("z".into())),
-                (Constant::Int(1), Constant::String("a".into())),
-                (Constant::Int(2), Constant::String("z".into())),
-                (Constant::Int(2), Constant::String("a".into())),
-            ]
-        );
-    }
-
-    #[test]
-    fn order_by_non_projected_column() {
-        // SELECT a FROM t ORDER BY b — b is not in the select list.
-        // Sort must run before projection or get_value("b") will fail.
-        let (db, txn, _dir) = setup_db();
-        let planner = basic_planner(&db);
-
-        exec(
-            &planner,
-            Arc::clone(&txn),
-            "create table t(a int, b varchar(10))",
-        );
-        for (a, b) in [(3, "a"), (1, "b"), (2, "c")] {
-            exec(
-                &planner,
-                Arc::clone(&txn),
-                &format!("insert into t(a,b) values ({a},'{b}')"),
-            );
-        }
-
-        let plan = planner
-            .create_query_plan(
-                "select a from t order by b asc".to_string(),
-                Arc::clone(&txn),
-            )
-            .unwrap();
-        let ctx = ExecutionContext::new(Arc::clone(&txn));
-        let mut scan = plan.open(&ctx);
-        scan.before_first().unwrap();
-        let mut rows = Vec::new();
-        while let Some(Ok(())) = scan.next() {
-            rows.push(scan.get_value("a").unwrap());
-        }
-        // sorted by b: "a"->3, "b"->1, "c"->2
-        assert_eq!(
-            rows,
-            vec![Constant::Int(3), Constant::Int(1), Constant::Int(2)]
-        );
-    }
 }
 
 #[cfg(test)]
@@ -4795,8 +4631,30 @@ mod heuristic_equivalence_tests {
         );
     }
 
+    fn collect_ordered<F, T>(
+        planner: &Planner,
+        txn: Arc<Transaction>,
+        sql: &str,
+        extract: F,
+    ) -> Vec<T>
+    where
+        F: Fn(&dyn Scan) -> T,
+    {
+        let plan = planner
+            .create_query_plan(sql.to_string(), Arc::clone(&txn))
+            .unwrap();
+        let ctx = ExecutionContext::new(txn);
+        let mut scan = plan.open(&ctx);
+        scan.before_first().unwrap();
+        let mut rows = Vec::new();
+        while let Some(Ok(())) = scan.next() {
+            rows.push(extract(scan.as_ref()));
+        }
+        rows
+    }
+
     #[test]
-    fn pipeline_planner_order_by_asc() {
+    fn order_by_asc_and_desc() {
         let (db, txn, _dir) = setup_db();
         let p = heuristic_planner(&db);
 
@@ -4809,36 +4667,37 @@ mod heuristic_equivalence_tests {
             );
         }
 
-        let plan = p
-            .create_query_plan(
-                "select a, b from t order by a asc".to_string(),
-                Arc::clone(&txn),
-            )
-            .unwrap();
-        let ctx = ExecutionContext::new(Arc::clone(&txn));
-        let mut scan = plan.open(&ctx);
-        scan.before_first().unwrap();
-        let mut rows = Vec::new();
-        while let Some(Ok(())) = scan.next() {
-            rows.push((scan.get_value("a").unwrap(), scan.get_value("b").unwrap()));
-        }
+        let asc = collect_ordered(
+            &p,
+            Arc::clone(&txn),
+            "select a from t order by a asc",
+            |s| s.get_value("a").unwrap(),
+        );
         assert_eq!(
-            rows,
-            vec![
-                (Constant::Int(1), Constant::String("a".into())),
-                (Constant::Int(2), Constant::String("b".into())),
-                (Constant::Int(3), Constant::String("c".into())),
-            ]
+            asc,
+            vec![Constant::Int(1), Constant::Int(2), Constant::Int(3)]
+        );
+
+        let desc = collect_ordered(
+            &p,
+            Arc::clone(&txn),
+            "select a from t order by a desc",
+            |s| s.get_value("a").unwrap(),
+        );
+        assert_eq!(
+            desc,
+            vec![Constant::Int(3), Constant::Int(2), Constant::Int(1)]
         );
     }
 
     #[test]
-    fn pipeline_planner_order_by_desc() {
+    fn order_by_non_projected_column() {
+        // Sort must run before projection so ORDER BY can reference columns not in the select list.
         let (db, txn, _dir) = setup_db();
         let p = heuristic_planner(&db);
 
         exec(&p, Arc::clone(&txn), "create table t(a int, b varchar(10))");
-        for (a, b) in [(3, "c"), (1, "a"), (2, "b")] {
+        for (a, b) in [(3, "a"), (1, "b"), (2, "c")] {
             exec(
                 &p,
                 Arc::clone(&txn),
@@ -4846,26 +4705,16 @@ mod heuristic_equivalence_tests {
             );
         }
 
-        let plan = p
-            .create_query_plan(
-                "select a, b from t order by b desc".to_string(),
-                Arc::clone(&txn),
-            )
-            .unwrap();
-        let ctx = ExecutionContext::new(Arc::clone(&txn));
-        let mut scan = plan.open(&ctx);
-        scan.before_first().unwrap();
-        let mut rows = Vec::new();
-        while let Some(Ok(())) = scan.next() {
-            rows.push((scan.get_value("a").unwrap(), scan.get_value("b").unwrap()));
-        }
+        // b is not projected; sorted by b asc -> "a"->3, "b"->1, "c"->2
+        let rows = collect_ordered(
+            &p,
+            Arc::clone(&txn),
+            "select a from t order by b asc",
+            |s| s.get_value("a").unwrap(),
+        );
         assert_eq!(
             rows,
-            vec![
-                (Constant::Int(3), Constant::String("c".into())),
-                (Constant::Int(2), Constant::String("b".into())),
-                (Constant::Int(1), Constant::String("a".into())),
-            ]
+            vec![Constant::Int(3), Constant::Int(1), Constant::Int(2)]
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4145,16 +4145,17 @@ impl HeuristicQueryPlanner {
             }
         }
 
-        let mut plan: Arc<dyn Plan> = Arc::new(ProjectPlan::new(
-            current_plan,
+        //  Sort before projection so ORDER BY can reference non-projected columns
+        let pre_project: Arc<dyn Plan> = if !order_by.is_empty() {
+            Arc::new(SortPlan::with_directions(current_plan, order_by))
+        } else {
+            current_plan
+        };
+
+        Ok(Arc::new(ProjectPlan::new(
+            pre_project,
             query_data.fields.iter().map(String::as_str).collect(),
-        )?);
-
-        if !order_by.is_empty() {
-            plan = Arc::new(SortPlan::with_directions(plan, order_by));
-        }
-
-        Ok(plan)
+        )?))
     }
 
     /// Find the [SelectPlan] with the lowest record output
@@ -4271,16 +4272,16 @@ impl QueryPlanner for BasicQueryPlanner {
         //  3. Create the selection with the predicate
         plan = Arc::new(SelectPlan::new(plan, query_data.predicate));
 
-        //  4. Create the projection
+        //  4. Sort before projection so ORDER BY can reference non-projected columns
+        if !query_data.order_by.is_empty() {
+            plan = Arc::new(SortPlan::with_directions(plan, query_data.order_by));
+        }
+
+        //  5. Create the projection
         plan = Arc::new(ProjectPlan::new(
             plan,
             query_data.fields.iter().map(AsRef::as_ref).collect(),
         )?);
-
-        //  5. Sort if ORDER BY was specified
-        if !query_data.order_by.is_empty() {
-            plan = Arc::new(SortPlan::with_directions(plan, query_data.order_by));
-        }
 
         Ok(plan)
     }
@@ -4583,6 +4584,46 @@ mod basic_query_planner_tests {
                 (Constant::Int(2), Constant::String("z".into())),
                 (Constant::Int(2), Constant::String("a".into())),
             ]
+        );
+    }
+
+    #[test]
+    fn order_by_non_projected_column() {
+        // SELECT a FROM t ORDER BY b — b is not in the select list.
+        // Sort must run before projection or get_value("b") will fail.
+        let (db, txn, _dir) = setup_db();
+        let planner = basic_planner(&db);
+
+        exec(
+            &planner,
+            Arc::clone(&txn),
+            "create table t(a int, b varchar(10))",
+        );
+        for (a, b) in [(3, "a"), (1, "b"), (2, "c")] {
+            exec(
+                &planner,
+                Arc::clone(&txn),
+                &format!("insert into t(a,b) values ({a},'{b}')"),
+            );
+        }
+
+        let plan = planner
+            .create_query_plan(
+                "select a from t order by b asc".to_string(),
+                Arc::clone(&txn),
+            )
+            .unwrap();
+        let ctx = ExecutionContext::new(Arc::clone(&txn));
+        let mut scan = plan.open(&ctx);
+        scan.before_first().unwrap();
+        let mut rows = Vec::new();
+        while let Some(Ok(())) = scan.next() {
+            rows.push(scan.get_value("a").unwrap());
+        }
+        // sorted by b: "a"->3, "b"->1, "c"->2
+        assert_eq!(
+            rows,
+            vec![Constant::Int(3), Constant::Int(1), Constant::Int(2)]
         );
     }
 }
@@ -5610,11 +5651,20 @@ impl QueryPlanner for PipelineQueryPlanner {
         let order_by = query_data.order_by.clone();
         let logical = BasicLogicalPlanner::new().build(query_data, &ctx)?;
         let optimized = HeuristicLogicalOptimizer::new().optimize(logical, &ctx)?;
-        let mut plan = DefaultPhysicalPlanner::new().lower(&optimized, &ctx)?;
-        if !order_by.is_empty() {
-            plan = Arc::new(SortPlan::with_directions(plan, order_by));
+
+        // Sort before projection so ORDER BY can reference non-projected columns.
+        // The optimized top node is always Project for a SELECT, so we lower the
+        // Project's input, wrap with SortPlan, then apply ProjectPlan on top.
+        if !order_by.is_empty() && optimized.kind() == LogicalPlanKind::Project {
+            let input = optimized.input().unwrap();
+            let fields = optimized.project_fields().unwrap();
+            let lowered = DefaultPhysicalPlanner::new().lower(input, &ctx)?;
+            let sorted: Arc<dyn Plan> = Arc::new(SortPlan::with_directions(lowered, order_by));
+            let field_refs: Vec<&str> = fields.iter().map(String::as_str).collect();
+            return Ok(Arc::new(ProjectPlan::new(sorted, field_refs)?));
         }
-        Ok(plan)
+
+        DefaultPhysicalPlanner::new().lower(&optimized, &ctx)
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -129,21 +129,48 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses a complete SELECT query
-    /// Returns: QueryData containing fields, tables, and predicates
+    /// Returns: QueryData containing fields, tables, predicates, and ORDER BY
     pub fn query(&mut self) -> Result<QueryData, ParserError> {
         self.lexer.eat_keyword("select")?;
         let select_list = self.select_list()?;
         self.lexer.eat_keyword("from")?;
         let table_list = self.select_tables()?;
-        let predicate = {
-            if self.lexer.match_keyword("where") {
-                self.lexer.eat_keyword("where")?;
-                self.parse_predicate()?
-            } else {
-                Predicate::new(Vec::new())
-            }
+        let predicate = if self.lexer.match_keyword("where") {
+            self.lexer.eat_keyword("where")?;
+            self.parse_predicate()?
+        } else {
+            Predicate::new(Vec::new())
         };
-        Ok(QueryData::new(select_list, table_list, predicate))
+        let order_by = if self.lexer.match_keyword("order") {
+            self.lexer.eat_keyword("order")?;
+            self.lexer.eat_keyword("by")?;
+            self.parse_order_by_list()?
+        } else {
+            Vec::new()
+        };
+        Ok(QueryData::new(select_list, table_list, predicate, order_by))
+    }
+
+    fn parse_order_by_list(&mut self) -> Result<Vec<(String, SortDirection)>, ParserError> {
+        let mut list = Vec::new();
+        loop {
+            let field = self.lexer.eat_identifier()?;
+            let dir = if self.lexer.match_keyword("desc") {
+                self.lexer.eat_keyword("desc")?;
+                SortDirection::Desc
+            } else {
+                if self.lexer.match_keyword("asc") {
+                    self.lexer.eat_keyword("asc")?;
+                }
+                SortDirection::Asc
+            };
+            list.push((field, dir));
+            if !self.lexer.match_delim(',') {
+                break;
+            }
+            self.lexer.eat_delim(',')?;
+        }
+        Ok(list)
     }
 
     /// Parses any SQL command that modifies the database
@@ -698,19 +725,32 @@ impl CreateIndexData {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SortDirection {
+    Asc,
+    Desc,
+}
+
 #[derive(Debug)]
 pub struct QueryData {
     pub fields: Vec<String>,
     pub tables: Vec<String>,
     pub predicate: Predicate,
+    pub order_by: Vec<(String, SortDirection)>,
 }
 
 impl QueryData {
-    fn new(fields: Vec<String>, tables: Vec<String>, predicate: Predicate) -> Self {
+    fn new(
+        fields: Vec<String>,
+        tables: Vec<String>,
+        predicate: Predicate,
+        order_by: Vec<(String, SortDirection)>,
+    ) -> Self {
         Self {
             fields,
             tables,
             predicate,
+            order_by,
         }
     }
 
@@ -751,6 +791,7 @@ impl<'a> Lexer<'a> {
         let keywords = [
             "select", "from", "where", "and", "or", "not", "insert", "into", "values", "delete",
             "update", "set", "create", "table", "int", "varchar", "view", "as", "index", "on",
+            "order", "by", "asc", "desc",
         ];
         let mut lexer = Self {
             input: string.chars().peekable(),


### PR DESCRIPTION
`SortPlan` already existed internally for merge join but was never exposed to SQL. This wires it up end-to-end.

**Parser** — `ORDER BY field [ASC|DESC], ...` is now recognised after the optional `WHERE` clause. Multiple sort columns are supported; `ASC` is the default when no direction keyword is given. `"order"`, `"by"`, `"asc"`, and `"desc"` are added to the keyword list. `QueryData` gains an `order_by: Vec<(String, SortDirection)>` field.

**RecordComparator** — now stores a direction per field and reverses the comparison for `DESC` columns. The existing `new(Vec<String>)` constructor defaults everything to `ASC`, so all merge-join call sites are unaffected. A new `with_directions` constructor is added for the ORDER BY path.

**SortPlan** — gains a `with_directions` constructor that accepts directed field specs. The original `new(Vec<String>)` is kept for merge join compatibility.

**Planners** — both `BasicQueryPlanner` and `HeuristicQueryPlanner` wrap the final `ProjectPlan` with a `SortPlan` when `order_by` is non-empty.

Three new tests cover single-column ASC, single-column DESC, and multi-column mixed-direction sorts.

Closes #110. Unblocks Payment (43%) and OrderStatus (4%) in the TPC-C tracking issue #109.