### PR TITLE
Add aggregate functions: MIN, MAX, SUM, COUNT(DISTINCT)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,22 @@ There is a test suite which provides basic coverage to ensure the code still wor
    - Note breaking changes (renamed methods, removed APIs, changed signatures) explicitly
    - No test plan checklist — CI covers that
 
+9. **Address PR review comments**
+   - Evaluate each comment: determine whether it identifies a genuine bug or design issue before acting
+   - Fix each distinct issue in a separate commit
+   - Reply to the comment thread using the GitHub API once the fix is committed and pushed:
+     ```bash
+     # List comment IDs for a PR
+     gh api repos/redixhumayun/simpledb/pulls/<PR>/comments --jq '.[] | {id: .id, login: .user.login, path: .path, body: .body[:80]}'
+
+     # Reply to a comment
+     gh api repos/redixhumayun/simpledb/pulls/<PR>/comments/<comment_id>/replies \
+       -f body="Fixed in <commit hash>.
+
+     <One or two sentences describing what changed and why.>"
+     ```
+   - Reply format: first line is "Fixed in <hash>.", blank line, then the brief explanation as a separate paragraph
+
 ### Profiling Workflow (REQUIRED for bottleneck analysis)
 Use this workflow when asked to profile a benchmark/workload and identify hotspots.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,8 @@ pub mod test_utils;
 pub use btree::BTreeIndex;
 pub use btree::SplitGate;
 use parser::{
-    CreateIndexData, CreateTableData, CreateViewData, DeleteData, InsertData, ModifyData, Parser,
-    QueryData, SortDirection,
+    AggregateOp, AggregateSpec, CreateIndexData, CreateTableData, CreateViewData, DeleteData,
+    InsertData, ModifyData, Parser, QueryData, SortDirection,
 };
 
 pub use test_utils::TestDir;
@@ -4145,6 +4145,11 @@ impl HeuristicQueryPlanner {
             }
         }
 
+        //  Apply aggregate functions before sorting/projection
+        if !query_data.aggregates.is_empty() {
+            current_plan = Arc::new(AggregatePlan::new(current_plan, query_data.aggregates));
+        }
+
         //  Sort before projection so ORDER BY can reference non-projected columns
         let pre_project = if !order_by.is_empty() {
             Arc::new(SortPlan::with_directions(current_plan, order_by))
@@ -4272,12 +4277,17 @@ impl QueryPlanner for BasicQueryPlanner {
         //  3. Create the selection with the predicate
         plan = Arc::new(SelectPlan::new(plan, query_data.predicate));
 
-        //  4. Sort before projection so ORDER BY can reference non-projected columns
+        //  4. Apply aggregate functions before sorting/projection
+        if !query_data.aggregates.is_empty() {
+            plan = Arc::new(AggregatePlan::new(plan, query_data.aggregates));
+        }
+
+        //  5. Sort before projection so ORDER BY can reference non-projected columns
         if !query_data.order_by.is_empty() {
             plan = Arc::new(SortPlan::with_directions(plan, query_data.order_by));
         }
 
-        //  5. Create the projection
+        //  6. Create the projection
         plan = Arc::new(ProjectPlan::new(
             plan,
             query_data.fields.iter().map(AsRef::as_ref).collect(),
@@ -4716,6 +4726,181 @@ mod heuristic_equivalence_tests {
             rows,
             vec![Constant::Int(3), Constant::Int(1), Constant::Int(2)]
         );
+    }
+}
+
+#[cfg(test)]
+mod aggregate_tests {
+    use super::*;
+
+    fn setup_db() -> (SimpleDB, Arc<Transaction>, test_utils::TestDir) {
+        let (db, dir) = SimpleDB::new_for_test(8, 5000);
+        let txn = db.new_tx();
+        (db, txn, dir)
+    }
+
+    fn basic_planner(db: &SimpleDB) -> Planner {
+        Planner::new(
+            Box::new(BasicQueryPlanner::new(Arc::clone(&db.metadata_manager))),
+            Box::new(IndexUpdatePlanner::new(Arc::clone(&db.metadata_manager))),
+        )
+    }
+
+    fn pipeline_planner(db: &SimpleDB) -> Planner {
+        Planner::new(
+            Box::new(PipelineQueryPlanner::new(Arc::clone(&db.metadata_manager))),
+            Box::new(IndexUpdatePlanner::new(Arc::clone(&db.metadata_manager))),
+        )
+    }
+
+    fn exec(planner: &Planner, txn: Arc<Transaction>, sql: &str) {
+        planner.execute_update(sql.to_string(), txn).unwrap();
+    }
+
+    fn fetch_single_int(planner: &Planner, txn: Arc<Transaction>, sql: &str, field: &str) -> i32 {
+        let plan = planner
+            .create_query_plan(sql.to_string(), Arc::clone(&txn))
+            .unwrap();
+        let ctx = ExecutionContext::new(txn);
+        let mut scan = plan.open(&ctx);
+        scan.before_first().unwrap();
+        assert!(
+            matches!(scan.next(), Some(Ok(()))),
+            "aggregate query produced no rows"
+        );
+        let val = scan.get_value(field).unwrap().as_int();
+        assert!(
+            scan.next().is_none(),
+            "aggregate query produced more than one row"
+        );
+        val
+    }
+
+    #[test]
+    fn test_max() {
+        let (db, txn, _dir) = setup_db();
+        let p = basic_planner(&db);
+        exec(&p, Arc::clone(&txn), "create table t(id int, score int)");
+        for (id, score) in [(1, 30), (2, 70), (3, 50)] {
+            exec(
+                &p,
+                Arc::clone(&txn),
+                &format!("insert into t(id, score) values ({id}, {score})"),
+            );
+        }
+        let result = fetch_single_int(
+            &p,
+            Arc::clone(&txn),
+            "select max(score) from t",
+            "max_score",
+        );
+        assert_eq!(result, 70);
+    }
+
+    #[test]
+    fn test_min() {
+        let (db, txn, _dir) = setup_db();
+        let p = basic_planner(&db);
+        exec(&p, Arc::clone(&txn), "create table t(id int, score int)");
+        for (id, score) in [(1, 30), (2, 70), (3, 50)] {
+            exec(
+                &p,
+                Arc::clone(&txn),
+                &format!("insert into t(id, score) values ({id}, {score})"),
+            );
+        }
+        let result = fetch_single_int(
+            &p,
+            Arc::clone(&txn),
+            "select min(score) from t",
+            "min_score",
+        );
+        assert_eq!(result, 30);
+    }
+
+    #[test]
+    fn test_sum() {
+        let (db, txn, _dir) = setup_db();
+        let p = basic_planner(&db);
+        exec(&p, Arc::clone(&txn), "create table t(id int, score int)");
+        for (id, score) in [(1, 10), (2, 20), (3, 30)] {
+            exec(
+                &p,
+                Arc::clone(&txn),
+                &format!("insert into t(id, score) values ({id}, {score})"),
+            );
+        }
+        let result = fetch_single_int(
+            &p,
+            Arc::clone(&txn),
+            "select sum(score) from t",
+            "sum_score",
+        );
+        assert_eq!(result, 60);
+    }
+
+    #[test]
+    fn test_count_distinct() {
+        let (db, txn, _dir) = setup_db();
+        let p = basic_planner(&db);
+        exec(&p, Arc::clone(&txn), "create table t(id int, cat int)");
+        // cat values: 1, 2, 2, 3 — 3 distinct
+        for (id, cat) in [(1, 1), (2, 2), (3, 2), (4, 3)] {
+            exec(
+                &p,
+                Arc::clone(&txn),
+                &format!("insert into t(id, cat) values ({id}, {cat})"),
+            );
+        }
+        let result = fetch_single_int(
+            &p,
+            Arc::clone(&txn),
+            "select count(distinct cat) from t",
+            "count_distinct_cat",
+        );
+        assert_eq!(result, 3);
+    }
+
+    #[test]
+    fn test_aggregate_with_where() {
+        let (db, txn, _dir) = setup_db();
+        let p = basic_planner(&db);
+        exec(&p, Arc::clone(&txn), "create table t(dept int, salary int)");
+        // dept 1: salaries 100, 200; dept 2: salaries 300, 400
+        for (dept, salary) in [(1, 100), (1, 200), (2, 300), (2, 400)] {
+            exec(
+                &p,
+                Arc::clone(&txn),
+                &format!("insert into t(dept, salary) values ({dept}, {salary})"),
+            );
+        }
+        let result = fetch_single_int(
+            &p,
+            Arc::clone(&txn),
+            "select max(salary) from t where dept = 1",
+            "max_salary",
+        );
+        assert_eq!(result, 200);
+    }
+
+    #[test]
+    fn test_aggregate_pipeline_planner() {
+        let (db, txn, _dir) = setup_db();
+        let p = pipeline_planner(&db);
+        exec(&p, Arc::clone(&txn), "create table t(id int, val int)");
+        for (id, val) in [(1, 5), (2, 15), (3, 10)] {
+            exec(
+                &p,
+                Arc::clone(&txn),
+                &format!("insert into t(id, val) values ({id}, {val})"),
+            );
+        }
+        let result = fetch_single_int(&p, Arc::clone(&txn), "select max(val) from t", "max_val");
+        assert_eq!(result, 15);
+        let result = fetch_single_int(&p, Arc::clone(&txn), "select min(val) from t", "min_val");
+        assert_eq!(result, 5);
+        let result = fetch_single_int(&p, Arc::clone(&txn), "select sum(val) from t", "sum_val");
+        assert_eq!(result, 30);
     }
 }
 
@@ -5498,22 +5683,55 @@ impl QueryPlanner for PipelineQueryPlanner {
     ) -> SimpleDBResult<Arc<dyn Plan>> {
         let ctx = PlanningContext::new(txn, Arc::clone(&self.metadata_manager));
         let order_by = query_data.order_by.clone();
-        let logical = BasicLogicalPlanner::new().build(query_data, &ctx)?;
+        let aggregates = query_data.aggregates.clone();
+        let has_aggregates = !aggregates.is_empty();
+        // Capture the intended output fields before potentially replacing with "*".
+        let final_fields: Vec<String> = if has_aggregates {
+            query_data.fields.clone()
+        } else {
+            vec![]
+        };
+
+        // For aggregate queries the logical planner sees a star projection so it
+        // doesn't try to look up aggregate alias names in the source schema.
+        let logical_query = if has_aggregates {
+            QueryData {
+                fields: vec!["*".to_string()],
+                tables: query_data.tables,
+                predicate: query_data.predicate,
+                order_by: query_data.order_by,
+                aggregates: vec![],
+            }
+        } else {
+            query_data
+        };
+
+        let logical = BasicLogicalPlanner::new().build(logical_query, &ctx)?;
         let optimized = HeuristicLogicalOptimizer::new().optimize(logical, &ctx)?;
 
         // BasicLogicalPlanner always produces a Project at the top of the tree.
         assert_eq!(optimized.kind(), LogicalPlanKind::Project);
 
         let input = optimized.input().unwrap();
-        let fields = optimized.project_fields().unwrap();
+        let logical_fields = optimized.project_fields().unwrap();
         let mut plan = DefaultPhysicalPlanner::new().lower(input, &ctx)?;
+
+        // Apply aggregates before sorting/projection.
+        if has_aggregates {
+            plan = Arc::new(AggregatePlan::new(plan, aggregates));
+        }
 
         // Sort before projection so ORDER BY can reference non-projected columns.
         if !order_by.is_empty() {
             plan = Arc::new(SortPlan::with_directions(plan, order_by));
         }
 
-        let field_refs: Vec<&str> = fields.iter().map(String::as_str).collect();
+        let proj_fields: Vec<String> = if has_aggregates {
+            final_fields
+        } else {
+            logical_fields.to_vec()
+        };
+        let field_refs: Vec<&str> = proj_fields.iter().map(String::as_str).collect();
         Ok(Arc::new(ProjectPlan::new(plan, field_refs)?))
     }
 }
@@ -5642,6 +5860,209 @@ impl Plan for ProjectPlan {
         println!("{}├─ Records: {}", prefix, self.records_output());
         println!("{prefix}├─ Child Plan:");
         self.plan.print_plan(indent + 1);
+        println!("{prefix}╰─");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AggregatePlan / AggregateScan
+// ---------------------------------------------------------------------------
+
+/// Runtime accumulator state for one aggregate expression.
+enum AggregateRunState {
+    /// Used for both Min and Max — None until the first row is seen.
+    MinMax(Option<Constant>),
+    Sum(i64),
+    CountDistinct(HashSet<Constant>),
+}
+
+/// A scan that consumes its source entirely on the first `next()` call, computes
+/// aggregate results, and then returns exactly one row.
+struct AggregateScan<S: Scan> {
+    source: S,
+    specs: Vec<AggregateSpec>,
+    /// Populated by the first `next()` call; `None` means not yet computed.
+    results: Option<HashMap<String, Constant>>,
+    exhausted: bool,
+}
+
+impl<S: Scan> AggregateScan<S> {
+    fn new(source: S, specs: Vec<AggregateSpec>) -> Self {
+        Self {
+            source,
+            specs,
+            results: None,
+            exhausted: false,
+        }
+    }
+
+    fn compute(&mut self) -> Result<(), Box<dyn Error>> {
+        let mut state: Vec<AggregateRunState> = self
+            .specs
+            .iter()
+            .map(|spec| match spec.op {
+                AggregateOp::Min | AggregateOp::Max => AggregateRunState::MinMax(None),
+                AggregateOp::Sum => AggregateRunState::Sum(0),
+                AggregateOp::CountDistinct => AggregateRunState::CountDistinct(HashSet::new()),
+            })
+            .collect();
+
+        while let Some(result) = self.source.next() {
+            result?;
+            for (i, spec) in self.specs.iter().enumerate() {
+                let val = self.source.get_value(&spec.field)?;
+                match (&spec.op, &mut state[i]) {
+                    (AggregateOp::Min, AggregateRunState::MinMax(curr)) => {
+                        *curr = Some(match curr.take() {
+                            None => val,
+                            Some(existing) => existing.min(val),
+                        });
+                    }
+                    (AggregateOp::Max, AggregateRunState::MinMax(curr)) => {
+                        *curr = Some(match curr.take() {
+                            None => val,
+                            Some(existing) => existing.max(val),
+                        });
+                    }
+                    (AggregateOp::Sum, AggregateRunState::Sum(total)) => {
+                        *total += val.as_int() as i64;
+                    }
+                    (AggregateOp::CountDistinct, AggregateRunState::CountDistinct(set)) => {
+                        set.insert(val);
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        let mut results = HashMap::new();
+        for (i, spec) in self.specs.iter().enumerate() {
+            let result_val = match &state[i] {
+                AggregateRunState::MinMax(curr) => curr.clone().unwrap_or(Constant::Int(0)),
+                AggregateRunState::Sum(total) => Constant::Int(*total as i32),
+                AggregateRunState::CountDistinct(set) => Constant::Int(set.len() as i32),
+            };
+            results.insert(spec.alias.clone(), result_val);
+        }
+        self.results = Some(results);
+        Ok(())
+    }
+}
+
+impl<S: Scan> Iterator for AggregateScan<S> {
+    type Item = Result<(), Box<dyn Error>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.exhausted {
+            return None;
+        }
+        self.exhausted = true;
+        Some(self.compute())
+    }
+}
+
+impl<S: Scan> Scan for AggregateScan<S> {
+    fn before_first(&mut self) -> SimpleDBResult<()> {
+        self.source.before_first()?;
+        self.results = None;
+        self.exhausted = false;
+        Ok(())
+    }
+
+    fn get_value(&self, field_name: &str) -> Result<Constant, Box<dyn Error>> {
+        self.results
+            .as_ref()
+            .ok_or_else(|| -> Box<dyn Error> {
+                "AggregateScan: get_value called before next()".into()
+            })
+            .and_then(|r| {
+                r.get(field_name).cloned().ok_or_else(|| {
+                    format!("field '{field_name}' not found in aggregate results").into()
+                })
+            })
+    }
+
+    fn has_field(&self, field_name: &str) -> Result<bool, Box<dyn Error>> {
+        Ok(self.specs.iter().any(|s| s.alias == field_name))
+    }
+}
+
+/// A plan node that wraps a source plan and applies whole-query aggregate
+/// functions (MIN, MAX, SUM, COUNT DISTINCT), producing exactly one output row.
+/// GROUP BY is not supported — this is for ungrouped aggregates only.
+struct AggregatePlan {
+    source: Arc<dyn Plan>,
+    specs: Vec<AggregateSpec>,
+    schema: Schema,
+}
+
+impl AggregatePlan {
+    fn new(source: Arc<dyn Plan>, specs: Vec<AggregateSpec>) -> Self {
+        let source_schema = source.schema();
+        let mut schema = Schema::new();
+        for spec in &specs {
+            match spec.op {
+                // COUNT always returns an integer.
+                AggregateOp::CountDistinct => schema.add_int_field(&spec.alias),
+                // SUM is always integer for now (no DECIMAL support yet).
+                AggregateOp::Sum => schema.add_int_field(&spec.alias),
+                // MIN/MAX preserve the input field's type.
+                AggregateOp::Min | AggregateOp::Max => {
+                    if let Some(info) = source_schema.info.get(&spec.field) {
+                        match info.field_type {
+                            FieldType::Int => schema.add_int_field(&spec.alias),
+                            FieldType::String => schema.add_string_field(&spec.alias, info.length),
+                        }
+                    } else {
+                        schema.add_int_field(&spec.alias);
+                    }
+                }
+            }
+        }
+        Self {
+            source,
+            specs,
+            schema,
+        }
+    }
+}
+
+impl Plan for AggregatePlan {
+    fn open(&self, ctx: &ExecutionContext) -> Box<dyn Scan> {
+        Box::new(AggregateScan::new(
+            self.source.open(ctx),
+            self.specs.clone(),
+        ))
+    }
+
+    fn blocks_accessed(&self) -> usize {
+        self.source.blocks_accessed()
+    }
+
+    fn records_output(&self) -> usize {
+        1
+    }
+
+    fn distinct_values(&self, _field_name: &str) -> usize {
+        1
+    }
+
+    fn schema(&self) -> Schema {
+        self.schema.clone()
+    }
+
+    fn print_plan_internal(&self, indent: usize) {
+        let prefix = "  ".repeat(indent);
+        println!("{prefix}╭─ AggregatePlan");
+        let specs_str: Vec<String> = self
+            .specs
+            .iter()
+            .map(|s| format!("{:?}({}) -> {}", s.op, s.field, s.alias))
+            .collect();
+        println!("{}├─ Aggregates: {:?}", prefix, specs_str);
+        println!("{}├─ Blocks: {}", prefix, self.blocks_accessed());
+        println!("{prefix}├─ Child Plan:");
+        self.source.print_plan(indent + 1);
         println!("{prefix}╰─");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4757,23 +4757,23 @@ mod aggregate_tests {
         planner.execute_update(sql.to_string(), txn).unwrap();
     }
 
-    fn fetch_single_int(planner: &Planner, txn: Arc<Transaction>, sql: &str, field: &str) -> i32 {
+    fn fetch_rows(
+        planner: &Planner,
+        txn: Arc<Transaction>,
+        sql: &str,
+        fields: &[&str],
+    ) -> Vec<Vec<Constant>> {
         let plan = planner
             .create_query_plan(sql.to_string(), Arc::clone(&txn))
             .unwrap();
         let ctx = ExecutionContext::new(txn);
         let mut scan = plan.open(&ctx);
         scan.before_first().unwrap();
-        assert!(
-            matches!(scan.next(), Some(Ok(()))),
-            "aggregate query produced no rows"
-        );
-        let val = scan.get_value(field).unwrap().as_int();
-        assert!(
-            scan.next().is_none(),
-            "aggregate query produced more than one row"
-        );
-        val
+        let mut out = Vec::new();
+        while let Some(Ok(())) = scan.next() {
+            out.push(fields.iter().map(|f| scan.get_value(f).unwrap()).collect());
+        }
+        out
     }
 
     #[test]
@@ -4788,13 +4788,15 @@ mod aggregate_tests {
                 &format!("insert into t(id, score) values ({id}, {score})"),
             );
         }
-        let result = fetch_single_int(
-            &p,
-            Arc::clone(&txn),
-            "select max(score) from t",
-            "max_score",
+        assert_eq!(
+            fetch_rows(
+                &p,
+                Arc::clone(&txn),
+                "select max(score) from t",
+                &["max_score"]
+            ),
+            vec![vec![Constant::Int(70)]]
         );
-        assert_eq!(result, 70);
     }
 
     #[test]
@@ -4809,13 +4811,15 @@ mod aggregate_tests {
                 &format!("insert into t(id, score) values ({id}, {score})"),
             );
         }
-        let result = fetch_single_int(
-            &p,
-            Arc::clone(&txn),
-            "select min(score) from t",
-            "min_score",
+        assert_eq!(
+            fetch_rows(
+                &p,
+                Arc::clone(&txn),
+                "select min(score) from t",
+                &["min_score"]
+            ),
+            vec![vec![Constant::Int(30)]]
         );
-        assert_eq!(result, 30);
     }
 
     #[test]
@@ -4830,13 +4834,15 @@ mod aggregate_tests {
                 &format!("insert into t(id, score) values ({id}, {score})"),
             );
         }
-        let result = fetch_single_int(
-            &p,
-            Arc::clone(&txn),
-            "select sum(score) from t",
-            "sum_score",
+        assert_eq!(
+            fetch_rows(
+                &p,
+                Arc::clone(&txn),
+                "select sum(score) from t",
+                &["sum_score"]
+            ),
+            vec![vec![Constant::Int(60)]]
         );
-        assert_eq!(result, 60);
     }
 
     #[test]
@@ -4852,13 +4858,15 @@ mod aggregate_tests {
                 &format!("insert into t(id, cat) values ({id}, {cat})"),
             );
         }
-        let result = fetch_single_int(
-            &p,
-            Arc::clone(&txn),
-            "select count(distinct cat) from t",
-            "count_distinct_cat",
+        assert_eq!(
+            fetch_rows(
+                &p,
+                Arc::clone(&txn),
+                "select count(distinct cat) from t",
+                &["count_distinct_cat"]
+            ),
+            vec![vec![Constant::Int(3)]]
         );
-        assert_eq!(result, 3);
     }
 
     #[test]
@@ -4874,13 +4882,15 @@ mod aggregate_tests {
                 &format!("insert into t(dept, salary) values ({dept}, {salary})"),
             );
         }
-        let result = fetch_single_int(
-            &p,
-            Arc::clone(&txn),
-            "select max(salary) from t where dept = 1",
-            "max_salary",
+        assert_eq!(
+            fetch_rows(
+                &p,
+                Arc::clone(&txn),
+                "select max(salary) from t where dept = 1",
+                &["max_salary"]
+            ),
+            vec![vec![Constant::Int(200)]]
         );
-        assert_eq!(result, 200);
     }
 
     #[test]
@@ -4895,12 +4905,18 @@ mod aggregate_tests {
                 &format!("insert into t(id, val) values ({id}, {val})"),
             );
         }
-        let result = fetch_single_int(&p, Arc::clone(&txn), "select max(val) from t", "max_val");
-        assert_eq!(result, 15);
-        let result = fetch_single_int(&p, Arc::clone(&txn), "select min(val) from t", "min_val");
-        assert_eq!(result, 5);
-        let result = fetch_single_int(&p, Arc::clone(&txn), "select sum(val) from t", "sum_val");
-        assert_eq!(result, 30);
+        assert_eq!(
+            fetch_rows(&p, Arc::clone(&txn), "select max(val) from t", &["max_val"]),
+            vec![vec![Constant::Int(15)]]
+        );
+        assert_eq!(
+            fetch_rows(&p, Arc::clone(&txn), "select min(val) from t", &["min_val"]),
+            vec![vec![Constant::Int(5)]]
+        );
+        assert_eq!(
+            fetch_rows(&p, Arc::clone(&txn), "select sum(val) from t", &["sum_val"]),
+            vec![vec![Constant::Int(30)]]
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5881,16 +5881,21 @@ enum AggregateRunState {
 struct AggregateScan<S: Scan> {
     source: S,
     specs: Vec<AggregateSpec>,
+    /// Type-correct defaults for MIN/MAX over an empty source (one per spec).
+    /// Computed by AggregatePlan from the source schema so the result type
+    /// matches the output schema even when no rows are seen.
+    empty_defaults: Vec<Constant>,
     /// Populated by the first `next()` call; `None` means not yet computed.
     results: Option<HashMap<String, Constant>>,
     exhausted: bool,
 }
 
 impl<S: Scan> AggregateScan<S> {
-    fn new(source: S, specs: Vec<AggregateSpec>) -> Self {
+    fn new(source: S, specs: Vec<AggregateSpec>, empty_defaults: Vec<Constant>) -> Self {
         Self {
             source,
             specs,
+            empty_defaults,
             results: None,
             exhausted: false,
         }
@@ -5938,7 +5943,9 @@ impl<S: Scan> AggregateScan<S> {
         let mut results = HashMap::new();
         for (i, spec) in self.specs.iter().enumerate() {
             let result_val = match &state[i] {
-                AggregateRunState::MinMax(curr) => curr.clone().unwrap_or(Constant::Int(0)),
+                AggregateRunState::MinMax(curr) => curr
+                    .clone()
+                    .unwrap_or_else(|| self.empty_defaults[i].clone()),
                 AggregateRunState::Sum(total) => Constant::Int(*total as i32),
                 AggregateRunState::CountDistinct(set) => Constant::Int(set.len() as i32),
             };
@@ -5994,27 +6001,44 @@ struct AggregatePlan {
     source: Arc<dyn Plan>,
     specs: Vec<AggregateSpec>,
     schema: Schema,
+    /// Type-correct default values for MIN/MAX when the source produces no rows.
+    empty_defaults: Vec<Constant>,
 }
 
 impl AggregatePlan {
     fn new(source: Arc<dyn Plan>, specs: Vec<AggregateSpec>) -> Self {
         let source_schema = source.schema();
         let mut schema = Schema::new();
+        let mut empty_defaults = Vec::with_capacity(specs.len());
+
         for spec in &specs {
             match spec.op {
                 // COUNT always returns an integer.
-                AggregateOp::CountDistinct => schema.add_int_field(&spec.alias),
+                AggregateOp::CountDistinct => {
+                    schema.add_int_field(&spec.alias);
+                    empty_defaults.push(Constant::Int(0));
+                }
                 // SUM is always integer for now (no DECIMAL support yet).
-                AggregateOp::Sum => schema.add_int_field(&spec.alias),
-                // MIN/MAX preserve the input field's type.
+                AggregateOp::Sum => {
+                    schema.add_int_field(&spec.alias);
+                    empty_defaults.push(Constant::Int(0));
+                }
+                // MIN/MAX preserve the input field's type and default accordingly.
                 AggregateOp::Min | AggregateOp::Max => {
                     if let Some(info) = source_schema.info.get(&spec.field) {
                         match info.field_type {
-                            FieldType::Int => schema.add_int_field(&spec.alias),
-                            FieldType::String => schema.add_string_field(&spec.alias, info.length),
+                            FieldType::Int => {
+                                schema.add_int_field(&spec.alias);
+                                empty_defaults.push(Constant::Int(0));
+                            }
+                            FieldType::String => {
+                                schema.add_string_field(&spec.alias, info.length);
+                                empty_defaults.push(Constant::String(String::new()));
+                            }
                         }
                     } else {
                         schema.add_int_field(&spec.alias);
+                        empty_defaults.push(Constant::Int(0));
                     }
                 }
             }
@@ -6023,6 +6047,7 @@ impl AggregatePlan {
             source,
             specs,
             schema,
+            empty_defaults,
         }
     }
 }
@@ -6032,6 +6057,7 @@ impl Plan for AggregatePlan {
         Box::new(AggregateScan::new(
             self.source.open(ctx),
             self.specs.clone(),
+            self.empty_defaults.clone(),
         ))
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -44,20 +44,26 @@ impl<'a> Parser<'a> {
     }
 
     /// Returns true if the current token starts an aggregate function call.
+    /// These are not reserved keywords so any identifier matching a function
+    /// name is treated as an aggregate only in the SELECT context.
     fn is_aggregate_fn(&self) -> bool {
-        self.lexer.match_keyword("min")
-            || self.lexer.match_keyword("max")
-            || self.lexer.match_keyword("sum")
-            || self.lexer.match_keyword("count")
+        self.lexer.match_identifier_value("min")
+            || self.lexer.match_identifier_value("max")
+            || self.lexer.match_identifier_value("sum")
+            || self.lexer.match_identifier_value("count")
     }
 
     /// Parses one aggregate expression: `MIN(field)`, `MAX(field)`, `SUM(field)`,
     /// or `COUNT(DISTINCT field)`.
     fn parse_aggregate(&mut self) -> Result<AggregateSpec, ParserError> {
-        if self.lexer.match_keyword("count") {
-            self.lexer.eat_keyword("count")?;
+        if self.lexer.match_identifier_value("count") {
+            self.lexer.eat_identifier()?;
             self.lexer.eat_delim('(')?;
-            self.lexer.eat_keyword("distinct")?;
+            // "distinct" is not a keyword — consume it as an identifier.
+            let kw = self.lexer.eat_identifier()?;
+            if kw != "distinct" {
+                return Err(ParserError::BadSyntax);
+            }
             let field = self.lexer.eat_identifier()?;
             self.lexer.eat_delim(')')?;
             let alias = format!("count_distinct_{field}");
@@ -68,14 +74,14 @@ impl<'a> Parser<'a> {
             });
         }
 
-        let (op, prefix) = if self.lexer.match_keyword("min") {
-            self.lexer.eat_keyword("min")?;
+        let (op, prefix) = if self.lexer.match_identifier_value("min") {
+            self.lexer.eat_identifier()?;
             (AggregateOp::Min, "min")
-        } else if self.lexer.match_keyword("max") {
-            self.lexer.eat_keyword("max")?;
+        } else if self.lexer.match_identifier_value("max") {
+            self.lexer.eat_identifier()?;
             (AggregateOp::Max, "max")
-        } else if self.lexer.match_keyword("sum") {
-            self.lexer.eat_keyword("sum")?;
+        } else if self.lexer.match_identifier_value("sum") {
+            self.lexer.eat_identifier()?;
             (AggregateOp::Sum, "sum")
         } else {
             return Err(ParserError::BadSyntax);
@@ -883,7 +889,7 @@ impl<'a> Lexer<'a> {
         let keywords = [
             "select", "from", "where", "and", "or", "not", "insert", "into", "values", "delete",
             "update", "set", "create", "table", "int", "varchar", "view", "as", "index", "on",
-            "order", "by", "asc", "desc", "min", "max", "sum", "count", "distinct",
+            "order", "by", "asc", "desc",
         ];
         let mut lexer = Self {
             input: string.chars().peekable(),
@@ -1049,6 +1055,11 @@ impl<'a> Lexer<'a> {
     /// Checks if current token is an identifier
     fn match_identifier(&self) -> bool {
         matches!(self.current_token, Some(Token::Identifier(_)))
+    }
+
+    /// Checks if current token is an identifier with the given value.
+    fn match_identifier_value(&self, value: &str) -> bool {
+        matches!(&self.current_token, Some(Token::Identifier(id)) if id == value)
     }
 
     /// Consumes and returns the current identifier

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -43,14 +43,79 @@ impl<'a> Parser<'a> {
         Ok(list)
     }
 
-    /// Parses the SELECT clause field list
-    /// Returns: Vec<String> containing selected field names
-    fn select_list(&mut self) -> Result<Vec<String>, ParserError> {
+    /// Returns true if the current token starts an aggregate function call.
+    fn is_aggregate_fn(&self) -> bool {
+        self.lexer.match_keyword("min")
+            || self.lexer.match_keyword("max")
+            || self.lexer.match_keyword("sum")
+            || self.lexer.match_keyword("count")
+    }
+
+    /// Parses one aggregate expression: `MIN(field)`, `MAX(field)`, `SUM(field)`,
+    /// or `COUNT(DISTINCT field)`.
+    fn parse_aggregate(&mut self) -> Result<AggregateSpec, ParserError> {
+        if self.lexer.match_keyword("count") {
+            self.lexer.eat_keyword("count")?;
+            self.lexer.eat_delim('(')?;
+            self.lexer.eat_keyword("distinct")?;
+            let field = self.lexer.eat_identifier()?;
+            self.lexer.eat_delim(')')?;
+            let alias = format!("count_distinct_{field}");
+            return Ok(AggregateSpec {
+                op: AggregateOp::CountDistinct,
+                field,
+                alias,
+            });
+        }
+
+        let (op, prefix) = if self.lexer.match_keyword("min") {
+            self.lexer.eat_keyword("min")?;
+            (AggregateOp::Min, "min")
+        } else if self.lexer.match_keyword("max") {
+            self.lexer.eat_keyword("max")?;
+            (AggregateOp::Max, "max")
+        } else if self.lexer.match_keyword("sum") {
+            self.lexer.eat_keyword("sum")?;
+            (AggregateOp::Sum, "sum")
+        } else {
+            return Err(ParserError::BadSyntax);
+        };
+
+        self.lexer.eat_delim('(')?;
+        let field = self.lexer.eat_identifier()?;
+        self.lexer.eat_delim(')')?;
+        let alias = format!("{prefix}_{field}");
+        Ok(AggregateSpec { op, field, alias })
+    }
+
+    /// Parses the SELECT clause field list.
+    /// Returns: (output field names, aggregate specs).  For plain fields the
+    /// spec list is empty; for aggregate items the alias appears in the field list
+    /// so the final ProjectPlan can reference it by name.
+    fn select_list(&mut self) -> Result<(Vec<String>, Vec<AggregateSpec>), ParserError> {
         if self.lexer.match_delim('*') {
             self.lexer.eat_delim('*')?;
-            return Ok(vec!["*".to_string()]);
+            return Ok((vec!["*".to_string()], vec![]));
         }
-        self.field_list()
+
+        let mut fields = Vec::new();
+        let mut aggregates = Vec::new();
+
+        loop {
+            if self.is_aggregate_fn() {
+                let spec = self.parse_aggregate()?;
+                fields.push(spec.alias.clone());
+                aggregates.push(spec);
+            } else {
+                fields.push(self.lexer.eat_identifier()?);
+            }
+            if !self.lexer.match_delim(',') {
+                break;
+            }
+            self.lexer.eat_delim(',')?;
+        }
+
+        Ok((fields, aggregates))
     }
 
     /// Parses the FROM clause table list
@@ -129,10 +194,10 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses a complete SELECT query
-    /// Returns: QueryData containing fields, tables, predicates, and ORDER BY
+    /// Returns: QueryData containing fields, tables, predicates, ORDER BY, and aggregates
     pub fn query(&mut self) -> Result<QueryData, ParserError> {
         self.lexer.eat_keyword("select")?;
-        let select_list = self.select_list()?;
+        let (select_fields, aggregates) = self.select_list()?;
         self.lexer.eat_keyword("from")?;
         let table_list = self.select_tables()?;
         let predicate = if self.lexer.match_keyword("where") {
@@ -148,7 +213,13 @@ impl<'a> Parser<'a> {
         } else {
             Vec::new()
         };
-        Ok(QueryData::new(select_list, table_list, predicate, order_by))
+        Ok(QueryData::new(
+            select_fields,
+            table_list,
+            predicate,
+            order_by,
+            aggregates,
+        ))
     }
 
     fn parse_order_by_list(&mut self) -> Result<Vec<(String, SortDirection)>, ParserError> {
@@ -731,12 +802,31 @@ pub enum SortDirection {
     Desc,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AggregateOp {
+    Min,
+    Max,
+    Sum,
+    CountDistinct,
+}
+
+/// One aggregate expression from a SELECT list, e.g. `MAX(o_id)`.
+#[derive(Debug, Clone)]
+pub struct AggregateSpec {
+    pub op: AggregateOp,
+    /// Input column name.
+    pub field: String,
+    /// Output column name in the result schema, e.g. `max_o_id`.
+    pub alias: String,
+}
+
 #[derive(Debug)]
 pub struct QueryData {
     pub fields: Vec<String>,
     pub tables: Vec<String>,
     pub predicate: Predicate,
     pub order_by: Vec<(String, SortDirection)>,
+    pub aggregates: Vec<AggregateSpec>,
 }
 
 impl QueryData {
@@ -745,12 +835,14 @@ impl QueryData {
         tables: Vec<String>,
         predicate: Predicate,
         order_by: Vec<(String, SortDirection)>,
+        aggregates: Vec<AggregateSpec>,
     ) -> Self {
         Self {
             fields,
             tables,
             predicate,
             order_by,
+            aggregates,
         }
     }
 
@@ -791,7 +883,7 @@ impl<'a> Lexer<'a> {
         let keywords = [
             "select", "from", "where", "and", "or", "not", "insert", "into", "values", "delete",
             "update", "set", "create", "table", "int", "varchar", "view", "as", "index", "on",
-            "order", "by", "asc", "desc",
+            "order", "by", "asc", "desc", "min", "max", "sum", "count", "distinct",
         ];
         let mut lexer = Self {
             input: string.chars().peekable(),


### PR DESCRIPTION
Part of #109 (TPC-C tracking). Closes #111.

**Parser** — `select_list()` now recognises `MIN(field)`, `MAX(field)`, `SUM(field)`, and `COUNT(DISTINCT field)` in the SELECT clause alongside plain field names. Each aggregate expression is parsed into an `AggregateSpec` (op, input field, output alias). The alias follows the pattern `<func>_<field>`, e.g. `MAX(o_id)` → `max_o_id`. `QueryData` gains a `pub aggregates: Vec<AggregateSpec>` field. Keywords `min`, `max`, `sum`, `count`, and `distinct` are added to the lexer.

**AggregateScan** — wraps any `Scan` and consumes it fully on the first `next()` call, computing running state per aggregate (`Option<Constant>` for MIN/MAX, `i64` for SUM, `HashSet<Constant>` for COUNT DISTINCT). Returns exactly one row; subsequent `next()` returns `None`. `before_first()` resets state so the scan is reusable.

**AggregatePlan** — wraps a source plan, builds a result schema from the `AggregateSpec` list (MIN/MAX preserve the input field type; SUM and COUNT DISTINCT always produce `int`), and delegates cost estimates to the source. `records_output()` is 1.

**Planners** — all three planners (`BasicQueryPlanner`, `HeuristicQueryPlanner`, `PipelineQueryPlanner`) insert `AggregatePlan` after the selection filter and before sort/projection. The `PipelineQueryPlanner` special-cases aggregate queries by presenting a star projection to the logical/optimizer layer (which cannot see aggregate alias names in the source schema) and re-applies the real field list at the physical level.

Six new tests cover MAX, MIN, SUM, COUNT(DISTINCT), aggregation with a WHERE predicate, and aggregation via the pipeline planner.

Unblocks OrderStatus (4%), Delivery (4%), and StockLevel (4%) in the TPC-C tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)