### PR TITLE
Add FLOAT/DECIMAL/NUMERIC type support

### DIFF
--- a/src/bin/simpledb-cli.rs
+++ b/src/bin/simpledb-cli.rs
@@ -208,6 +208,7 @@ fn describe_table(db: &SimpleDB, table_name: &str) -> Result<String, Box<dyn Err
         let field_info = &layout.schema.info[field];
         let type_str = match field_info.field_type {
             FieldType::Int => "int".to_string(),
+            FieldType::Float => "float".to_string(),
             FieldType::String => format!("varchar({})", field_info.length),
         };
         result.push_str(&format!("{:<20} {:<15}\n", field, type_str));
@@ -341,6 +342,7 @@ fn execute_update(
 fn format_value(value: &Constant) -> String {
     match value {
         Constant::Int(i) => i.to_string(),
+        Constant::Float(f) => f.to_string(),
         Constant::String(s) => s.clone(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8262,6 +8262,16 @@ impl PredicateRangeState {
     }
 }
 
+/// Promotes an Int/Float mixed pair to (Float, Float) so comparisons are numeric.
+/// Same-type pairs are returned unchanged.
+fn coerce_numeric_pair(a: Constant, b: Constant) -> (Constant, Constant) {
+    match (&a, &b) {
+        (Constant::Int(i), Constant::Float(_)) => (Constant::Float(*i as f64), b),
+        (Constant::Float(_), Constant::Int(i)) => (a, Constant::Float(*i as f64)),
+        _ => (a, b),
+    }
+}
+
 impl Term {
     pub fn new(lhs: Expression, rhs: Expression) -> Self {
         Self {
@@ -8285,6 +8295,7 @@ impl Term {
     {
         let lhs = self.lhs.evaluate(scan)?;
         let rhs = self.rhs.evaluate(scan)?;
+        let (lhs, rhs) = coerce_numeric_pair(lhs, rhs);
 
         match self.comparison_op {
             ComparisonOp::Equal => Ok(lhs == rhs),

--- a/src/main.rs
+++ b/src/main.rs
@@ -908,6 +908,7 @@ impl Scan for ChunkScan {
         })?;
         match self.layout.schema.info.get(field_name).unwrap().field_type {
             FieldType::Int => Ok(Constant::Int(record_page.get_int(slot, field_name)?)),
+            FieldType::Float => Ok(Constant::Float(record_page.get_float(slot, field_name)?)),
             FieldType::String => Ok(Constant::String(record_page.get_string(slot, field_name)?)),
         }
     }
@@ -3607,6 +3608,7 @@ impl UpdatePlanner for IndexUpdatePlanner {
                 field_map.get(f.as_str()).cloned().unwrap_or_else(|| {
                     match schema.info[f].field_type {
                         FieldType::Int => Constant::Int(0),
+                        FieldType::Float => Constant::Float(0.0),
                         FieldType::String => Constant::String(String::new()),
                     }
                 })
@@ -3787,6 +3789,7 @@ impl UpdatePlanner for BasicUpdatePlanner {
                 field_map.get(f.as_str()).cloned().unwrap_or_else(|| {
                     match schema.info[f].field_type {
                         FieldType::Int => Constant::Int(0),
+                        FieldType::Float => Constant::Float(0.0),
                         FieldType::String => Constant::String(String::new()),
                     }
                 })
@@ -5888,7 +5891,7 @@ impl Plan for ProjectPlan {
 enum AggregateRunState {
     /// Used for both Min and Max — None until the first row is seen.
     MinMax(Option<Constant>),
-    Sum(i64),
+    Sum(f64),
     CountDistinct(HashSet<Constant>),
 }
 
@@ -5923,7 +5926,7 @@ impl<S: Scan> AggregateScan<S> {
             .iter()
             .map(|spec| match spec.op {
                 AggregateOp::Min | AggregateOp::Max => AggregateRunState::MinMax(None),
-                AggregateOp::Sum => AggregateRunState::Sum(0),
+                AggregateOp::Sum => AggregateRunState::Sum(0.0),
                 AggregateOp::CountDistinct => AggregateRunState::CountDistinct(HashSet::new()),
             })
             .collect();
@@ -5946,7 +5949,11 @@ impl<S: Scan> AggregateScan<S> {
                         });
                     }
                     (AggregateOp::Sum, AggregateRunState::Sum(total)) => {
-                        *total += val.as_int() as i64;
+                        *total += match val {
+                            Constant::Int(v) => v as f64,
+                            Constant::Float(v) => v,
+                            _ => val.as_int() as f64,
+                        };
                     }
                     (AggregateOp::CountDistinct, AggregateRunState::CountDistinct(set)) => {
                         set.insert(val);
@@ -5962,7 +5969,10 @@ impl<S: Scan> AggregateScan<S> {
                 AggregateRunState::MinMax(curr) => curr
                     .clone()
                     .unwrap_or_else(|| self.empty_defaults[i].clone()),
-                AggregateRunState::Sum(total) => Constant::Int(*total as i32),
+                AggregateRunState::Sum(total) => match &self.empty_defaults[i] {
+                    Constant::Float(_) => Constant::Float(*total),
+                    _ => Constant::Int(*total as i64 as i32),
+                },
                 AggregateRunState::CountDistinct(set) => Constant::Int(set.len() as i32),
             };
             results.insert(spec.alias.clone(), result_val);
@@ -6034,10 +6044,20 @@ impl AggregatePlan {
                     schema.add_int_field(&spec.alias);
                     empty_defaults.push(Constant::Int(0));
                 }
-                // SUM is always integer for now (no DECIMAL support yet).
+                // SUM preserves the input field's numeric type.
                 AggregateOp::Sum => {
-                    schema.add_int_field(&spec.alias);
-                    empty_defaults.push(Constant::Int(0));
+                    if let Some(info) = source_schema.info.get(&spec.field) {
+                        if info.field_type == FieldType::Float {
+                            schema.add_float_field(&spec.alias);
+                            empty_defaults.push(Constant::Float(0.0));
+                        } else {
+                            schema.add_int_field(&spec.alias);
+                            empty_defaults.push(Constant::Int(0));
+                        }
+                    } else {
+                        schema.add_int_field(&spec.alias);
+                        empty_defaults.push(Constant::Int(0));
+                    }
                 }
                 // MIN/MAX preserve the input field's type and default accordingly.
                 AggregateOp::Min | AggregateOp::Max => {
@@ -6046,6 +6066,10 @@ impl AggregatePlan {
                             FieldType::Int => {
                                 schema.add_int_field(&spec.alias);
                                 empty_defaults.push(Constant::Int(0));
+                            }
+                            FieldType::Float => {
+                                schema.add_float_field(&spec.alias);
+                                empty_defaults.push(Constant::Float(0.0));
                             }
                             FieldType::String => {
                                 schema.add_string_field(&spec.alias, info.length);
@@ -8511,6 +8535,7 @@ impl Expression {
         match self {
             Expression::Constant(constant) => match constant {
                 Constant::Int(value) => value.to_string(),
+                Constant::Float(value) => value.to_string(),
                 Constant::String(string) => string.to_string(),
             },
             Expression::FieldName(field_name) => field_name.clone(),
@@ -8673,6 +8698,7 @@ mod metadata_manager_tests {
             let field_info = layout.schema.info.get(field).unwrap();
             let type_str = match field_info.field_type {
                 FieldType::Int => "int".to_string(),
+                FieldType::Float => "float".to_string(),
                 FieldType::String => format!("varchar({})", field_info.length),
             };
             println!("{field}: {type_str}");
@@ -9003,6 +9029,9 @@ impl IndexInfo {
         match table_schema.info.get(field_name).unwrap().field_type {
             FieldType::Int => {
                 schema.add_int_field(Self::DATA_FIELD);
+            }
+            FieldType::Float => {
+                schema.add_float_field(Self::DATA_FIELD);
             }
             FieldType::String => {
                 let field_length = table_schema.info.get(field_name).unwrap().length;
@@ -9656,6 +9685,7 @@ mod table_manager_tests {
             let field_info = layout.schema.info.get(field).unwrap();
             let type_str = match field_info.field_type {
                 FieldType::Int => "int".to_string(),
+                FieldType::Float => "float".to_string(),
                 FieldType::String => format!("varchar({})", field_info.length),
             };
             println!("{field}: {type_str}");
@@ -9889,6 +9919,7 @@ impl Scan for TableScan {
         })?;
         match self.layout.schema.info.get(field_name).unwrap().field_type {
             FieldType::Int => Ok(Constant::Int(page.get_int(slot, field_name)?)),
+            FieldType::Float => Ok(Constant::Float(page.get_float(slot, field_name)?)),
             FieldType::String => Ok(Constant::String(page.get_string(slot, field_name)?)),
         }
     }
@@ -9910,6 +9941,11 @@ impl TableCursor for TableScan {
                 *self.current_slot.as_ref().unwrap(),
                 field_name,
                 value.as_int(),
+            )?,
+            FieldType::Float => self.record_page.as_ref().unwrap().set_float(
+                *self.current_slot.as_ref().unwrap(),
+                field_name,
+                value.as_float(),
             )?,
             FieldType::String => self.record_page.as_ref().unwrap().set_string(
                 *self.current_slot.as_ref().unwrap(),
@@ -10134,10 +10170,65 @@ mod table_scan_tests {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug)]
 pub enum Constant {
     Int(i32),
+    Float(f64),
     String(String),
+}
+
+impl PartialEq for Constant {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Constant::Int(a), Constant::Int(b)) => a == b,
+            (Constant::Float(a), Constant::Float(b)) => a.to_bits() == b.to_bits(),
+            (Constant::String(a), Constant::String(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Constant {}
+
+impl std::hash::Hash for Constant {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Constant::Int(v) => {
+                0i32.hash(state);
+                v.hash(state);
+            }
+            Constant::Float(v) => {
+                2i32.hash(state);
+                v.to_bits().hash(state);
+            }
+            Constant::String(s) => {
+                1i32.hash(state);
+                s.hash(state);
+            }
+        }
+    }
+}
+
+impl PartialOrd for Constant {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Constant {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match (self, other) {
+            (Constant::Int(a), Constant::Int(b)) => a.cmp(b),
+            (Constant::Float(a), Constant::Float(b)) => a.partial_cmp(b).unwrap_or(Ordering::Equal),
+            (Constant::String(a), Constant::String(b)) => a.cmp(b),
+            // Cross-type ordering: Int < Float < String
+            (Constant::Int(_), _) => Ordering::Less,
+            (_, Constant::Int(_)) => Ordering::Greater,
+            (Constant::Float(_), Constant::String(_)) => Ordering::Less,
+            (Constant::String(_), Constant::Float(_)) => Ordering::Greater,
+        }
+    }
 }
 
 impl Constant {
@@ -10145,6 +10236,13 @@ impl Constant {
         match self {
             Constant::Int(value) => *value,
             _ => panic!("Expected an integer constant"),
+        }
+    }
+
+    pub fn as_float(&self) -> f64 {
+        match self {
+            Constant::Float(value) => *value,
+            _ => panic!("Expected a float constant"),
         }
     }
 
@@ -10156,13 +10254,15 @@ impl Constant {
     }
 
     fn serialized_size(&self) -> usize {
-        const TYPE_TAG_SIZE: usize = 4; // i32 for type tag
-        const INT_SIZE: usize = 4; // i32 for integer value
-        const STR_LEN_SIZE: usize = 4; // i32 for string length
+        const TYPE_TAG_SIZE: usize = 4;
+        const INT_SIZE: usize = 4;
+        const FLOAT_SIZE: usize = 8;
+        const STR_LEN_SIZE: usize = 4;
 
         TYPE_TAG_SIZE
             + match self {
                 Constant::Int(_) => INT_SIZE,
+                Constant::Float(_) => FLOAT_SIZE,
                 Constant::String(s) => STR_LEN_SIZE + s.len(),
             }
     }
@@ -10170,6 +10270,7 @@ impl Constant {
     fn successor(&self) -> Option<Constant> {
         match self {
             Constant::Int(value) => value.checked_add(1).map(Constant::Int),
+            Constant::Float(_) => None,
             Constant::String(value) => {
                 let mut next = value.clone();
                 next.push('\0');
@@ -10182,11 +10283,21 @@ impl Constant {
 impl TryInto<Vec<u8>> for Constant {
     type Error = Box<dyn Error>;
 
+    /// Encodes with a 4-byte little-endian type tag so all variants are unambiguous:
+    /// tag 0 = Int (4 bytes), tag 1 = String (4-byte len + bytes), tag 2 = Float (8 bytes).
     fn try_into(self) -> Result<Vec<u8>, Self::Error> {
         let mut buf = Vec::new();
         match self {
-            Constant::Int(v) => buf.extend_from_slice(&v.to_le_bytes()),
+            Constant::Int(v) => {
+                buf.extend_from_slice(&0i32.to_le_bytes());
+                buf.extend_from_slice(&v.to_le_bytes());
+            }
+            Constant::Float(v) => {
+                buf.extend_from_slice(&2i32.to_le_bytes());
+                buf.extend_from_slice(&v.to_bits().to_le_bytes());
+            }
             Constant::String(s) => {
+                buf.extend_from_slice(&1i32.to_le_bytes());
                 let len: u32 = s
                     .len()
                     .try_into()
@@ -10268,6 +10379,21 @@ impl RecordPage {
             .to_string())
     }
 
+    fn get_float(&self, slot: usize, field_name: &str) -> SimpleDBResult<f64> {
+        self.txn
+            .lock_row_s(self.table_id, RID::new(self.block_id.block_num, slot))?;
+        Ok(self
+            .txn
+            .pin_read_guard(&self.block_id)?
+            .into_heap_view(&self.layout)
+            .unwrap()
+            .row(slot)
+            .unwrap()
+            .get_column(field_name)
+            .unwrap()
+            .as_float())
+    }
+
     /// Sets an integer value in the specified slot and field.
     fn set_int(&self, slot: usize, field_name: &str, value: i32) -> SimpleDBResult<()> {
         self.txn
@@ -10296,6 +10422,22 @@ impl RecordPage {
             .row_mut(slot)?
             .ok_or_else(|| -> Box<dyn Error> { format!("slot {slot} not found").into() })?;
         row.set_column(field_name, &Constant::String(value.to_string()))
+            .ok_or_else(|| -> Box<dyn Error> {
+                format!("field '{field_name}' not in schema").into()
+            })?;
+        Ok(())
+    }
+
+    fn set_float(&self, slot: usize, field_name: &str, value: f64) -> SimpleDBResult<()> {
+        self.txn
+            .lock_row_x(self.table_id, RID::new(self.block_id.block_num, slot))?;
+        let ws = self.txn.write_session();
+        let guard = ws.pin_write_guard(&self.block_id)?;
+        let mut view = guard.into_heap_view_mut(&self.layout)?;
+        let mut row = view
+            .row_mut(slot)?
+            .ok_or_else(|| -> Box<dyn Error> { format!("slot {slot} not found").into() })?;
+        row.set_column(field_name, &Constant::Float(value))
             .ok_or_else(|| -> Box<dyn Error> {
                 format!("field '{field_name}' not in schema").into()
             })?;
@@ -10472,6 +10614,7 @@ impl Layout {
             let info = self.schema.info.get(f)?;
             match info.field_type {
                 FieldType::Int => offset += info.length,
+                FieldType::Float => offset += info.length,
                 FieldType::String => offset += Self::INT_BYTES + info.length,
             }
         }
@@ -10489,6 +10632,7 @@ impl Layout {
             let info = self.schema.info.get(f).unwrap();
             match info.field_type {
                 FieldType::Int => size += info.length,
+                FieldType::Float => size += info.length,
                 FieldType::String => size += Self::INT_BYTES + info.length,
             }
         }
@@ -10514,6 +10658,7 @@ impl Layout {
         for value in values {
             match value {
                 Constant::Int(v) => buf.extend_from_slice(&v.to_le_bytes()),
+                Constant::Float(v) => buf.extend_from_slice(&v.to_bits().to_le_bytes()),
                 Constant::String(s) => {
                     buf.extend_from_slice(&(s.len() as u32).to_le_bytes());
                     buf.extend_from_slice(s.as_bytes());
@@ -10572,6 +10717,9 @@ impl Layout {
                     Some(Constant::Int(v)) => {
                         data.extend_from_slice(&v.to_le_bytes());
                     }
+                    Some(Constant::Float(v)) => {
+                        data.extend_from_slice(&v.to_bits().to_le_bytes());
+                    }
                     Some(Constant::String(s)) => {
                         data.extend_from_slice(&(s.len() as u32).to_le_bytes());
                         data.extend_from_slice(s.as_bytes());
@@ -10604,6 +10752,7 @@ impl Layout {
             let info = self.schema.info.get(fname)?;
             match info.field_type {
                 FieldType::Int => offset += 4,
+                FieldType::Float => offset += 8,
                 FieldType::String => {
                     let len =
                         u32::from_le_bytes(payload[offset..offset + 4].try_into().ok()?) as usize;
@@ -10616,6 +10765,9 @@ impl Layout {
             FieldType::Int => Some(Constant::Int(i32::from_le_bytes(
                 payload[offset..offset + 4].try_into().ok()?,
             ))),
+            FieldType::Float => Some(Constant::Float(f64::from_bits(u64::from_le_bytes(
+                payload[offset..offset + 8].try_into().ok()?,
+            )))),
             FieldType::String => {
                 let len = u32::from_le_bytes(payload[offset..offset + 4].try_into().ok()?) as usize;
                 Some(Constant::String(
@@ -10645,6 +10797,11 @@ impl Layout {
                     let v = i32::from_le_bytes(payload[offset..offset + 4].try_into().unwrap());
                     result.push(Some(Constant::Int(v)));
                     offset += 4;
+                }
+                FieldType::Float => {
+                    let bits = u64::from_le_bytes(payload[offset..offset + 8].try_into().unwrap());
+                    result.push(Some(Constant::Float(f64::from_bits(bits))));
+                    offset += 8;
                 }
                 FieldType::String => {
                     let len = u32::from_le_bytes(payload[offset..offset + 4].try_into().unwrap())
@@ -10688,6 +10845,7 @@ mod layout_tests {
 pub enum FieldType {
     Int = 0,
     String = 1,
+    Float = 2,
 }
 
 impl From<i32> for FieldType {
@@ -10695,6 +10853,7 @@ impl From<i32> for FieldType {
         match value {
             0 => FieldType::Int,
             1 => FieldType::String,
+            2 => FieldType::Float,
             _ => panic!("Invalid field type"),
         }
     }
@@ -10740,8 +10899,14 @@ impl Schema {
             .or_insert_with(|| FieldInfo { field_type, length });
     }
 
+    const FLOAT_BYTES: usize = 8;
+
     fn add_int_field(&mut self, field_name: &str) {
         self.add_field(field_name, FieldType::Int, Self::INT_BYTES);
+    }
+
+    pub fn add_float_field(&mut self, field_name: &str) {
+        self.add_field(field_name, FieldType::Float, Self::FLOAT_BYTES);
     }
 
     fn add_string_field(&mut self, field_name: &str, length: usize) {
@@ -13540,6 +13705,10 @@ impl From<&LogRecord> for Vec<u8> {
                         push_i32(&mut buf, 0); // type tag for Int
                         push_i32(&mut buf, *v);
                     }
+                    Constant::Float(v) => {
+                        push_i32(&mut buf, 2); // type tag for Float
+                        buf.extend_from_slice(&v.to_bits().to_le_bytes());
+                    }
                     Constant::String(s) => {
                         push_i32(&mut buf, 1); // type tag for String
                         push_string(&mut buf, s);
@@ -13597,6 +13766,10 @@ impl From<&LogRecord> for Vec<u8> {
                     Constant::Int(v) => {
                         push_i32(&mut buf, 0); // type tag for Int
                         push_i32(&mut buf, *v);
+                    }
+                    Constant::Float(v) => {
+                        push_i32(&mut buf, 2); // type tag for Float
+                        buf.extend_from_slice(&v.to_bits().to_le_bytes());
                     }
                     Constant::String(s) => {
                         push_i32(&mut buf, 1); // type tag for String
@@ -13931,6 +14104,7 @@ impl TryFrom<Vec<u8>> for LogRecord {
                 let key = match key_type {
                     0 => Constant::Int(read_i32(&value, &mut pos)?),
                     1 => Constant::String(read_string(&value, &mut pos)?),
+                    2 => Constant::Float(f64::from_bits(read_u64(&value, &mut pos)?)),
                     _ => return Err("invalid constant type tag".into()),
                 };
                 let rid = RID::new(read_usize(&value, &mut pos)?, read_usize(&value, &mut pos)?);
@@ -13985,6 +14159,7 @@ impl TryFrom<Vec<u8>> for LogRecord {
                 let key = match key_type {
                     0 => Constant::Int(read_i32(&value, &mut pos)?),
                     1 => Constant::String(read_string(&value, &mut pos)?),
+                    2 => Constant::Float(f64::from_bits(read_u64(&value, &mut pos)?)),
                     _ => return Err("invalid constant type tag".into()),
                 };
                 let child_block = read_usize(&value, &mut pos)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10231,7 +10231,7 @@ impl Ord for Constant {
         use std::cmp::Ordering;
         match (self, other) {
             (Constant::Int(a), Constant::Int(b)) => a.cmp(b),
-            (Constant::Float(a), Constant::Float(b)) => a.partial_cmp(b).unwrap_or(Ordering::Equal),
+            (Constant::Float(a), Constant::Float(b)) => a.total_cmp(b),
             (Constant::String(a), Constant::String(b)) => a.cmp(b),
             // Cross-type ordering: Int < Float < String
             (Constant::Int(_), _) => Ordering::Less,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5891,7 +5891,8 @@ impl Plan for ProjectPlan {
 enum AggregateRunState {
     /// Used for both Min and Max — None until the first row is seen.
     MinMax(Option<Constant>),
-    Sum(f64),
+    SumInt(i64),
+    SumFloat(f64),
     CountDistinct(HashSet<Constant>),
 }
 
@@ -5924,9 +5925,13 @@ impl<S: Scan> AggregateScan<S> {
         let mut state: Vec<AggregateRunState> = self
             .specs
             .iter()
-            .map(|spec| match spec.op {
+            .enumerate()
+            .map(|(i, spec)| match spec.op {
                 AggregateOp::Min | AggregateOp::Max => AggregateRunState::MinMax(None),
-                AggregateOp::Sum => AggregateRunState::Sum(0.0),
+                AggregateOp::Sum => match &self.empty_defaults[i] {
+                    Constant::Float(_) => AggregateRunState::SumFloat(0.0),
+                    _ => AggregateRunState::SumInt(0),
+                },
                 AggregateOp::CountDistinct => AggregateRunState::CountDistinct(HashSet::new()),
             })
             .collect();
@@ -5948,10 +5953,16 @@ impl<S: Scan> AggregateScan<S> {
                             Some(existing) => existing.max(val),
                         });
                     }
-                    (AggregateOp::Sum, AggregateRunState::Sum(total)) => {
+                    (AggregateOp::Sum, AggregateRunState::SumInt(total)) => {
                         *total += match val {
-                            Constant::Int(v) => v as f64,
+                            Constant::Int(v) => v as i64,
+                            _ => val.as_int() as i64,
+                        };
+                    }
+                    (AggregateOp::Sum, AggregateRunState::SumFloat(total)) => {
+                        *total += match val {
                             Constant::Float(v) => v,
+                            Constant::Int(v) => v as f64,
                             _ => val.as_int() as f64,
                         };
                     }
@@ -5969,10 +5980,8 @@ impl<S: Scan> AggregateScan<S> {
                 AggregateRunState::MinMax(curr) => curr
                     .clone()
                     .unwrap_or_else(|| self.empty_defaults[i].clone()),
-                AggregateRunState::Sum(total) => match &self.empty_defaults[i] {
-                    Constant::Float(_) => Constant::Float(*total),
-                    _ => Constant::Int(*total as i64 as i32),
-                },
+                AggregateRunState::SumInt(total) => Constant::Int(*total as i32),
+                AggregateRunState::SumFloat(total) => Constant::Float(*total),
                 AggregateRunState::CountDistinct(set) => Constant::Int(set.len() as i32),
             };
             results.insert(spec.alias.clone(), result_val);

--- a/src/page.rs
+++ b/src/page.rs
@@ -4198,6 +4198,9 @@ impl BTreeLeafEntry {
             Constant::Int(v) => {
                 bytes[key_offset..key_offset + 4].copy_from_slice(&v.to_le_bytes());
             }
+            Constant::Float(v) => {
+                bytes[key_offset..key_offset + 8].copy_from_slice(&v.to_bits().to_le_bytes());
+            }
             Constant::String(s) => {
                 let len = s.len() as u32;
                 bytes[key_offset..key_offset + 4].copy_from_slice(&len.to_le_bytes());
@@ -4232,6 +4235,10 @@ impl BTreeLeafEntry {
             FieldType::Int => {
                 let val = i32::from_le_bytes(bytes[key_offset..key_offset + 4].try_into()?);
                 Constant::Int(val)
+            }
+            FieldType::Float => {
+                let bits = u64::from_le_bytes(bytes[key_offset..key_offset + 8].try_into()?);
+                Constant::Float(f64::from_bits(bits))
             }
             FieldType::String => {
                 let len =
@@ -4279,6 +4286,9 @@ impl BTreeInternalEntry {
             Constant::Int(v) => {
                 bytes[key_offset..key_offset + 4].copy_from_slice(&v.to_le_bytes());
             }
+            Constant::Float(v) => {
+                bytes[key_offset..key_offset + 8].copy_from_slice(&v.to_bits().to_le_bytes());
+            }
             Constant::String(s) => {
                 let len = s.len() as u32;
                 bytes[key_offset..key_offset + 4].copy_from_slice(&len.to_le_bytes());
@@ -4309,6 +4319,10 @@ impl BTreeInternalEntry {
             FieldType::Int => {
                 let val = i32::from_le_bytes(bytes[key_offset..key_offset + 4].try_into()?);
                 Constant::Int(val)
+            }
+            FieldType::Float => {
+                let bits = u64::from_le_bytes(bytes[key_offset..key_offset + 8].try_into()?);
+                Constant::Float(f64::from_bits(bits))
             }
             FieldType::String => {
                 let len =
@@ -6152,22 +6166,30 @@ impl<'a> BTreeLeafPage<'a> {
         self.record_space.bytes.get(start..start + len)
     }
 
-    /// Decode high key using leaf encoding (int or len+utf8 string).
+    /// Decode high key. Encoding uses a 4-byte little-endian type tag:
+    /// 0 = Int (next 4 bytes), 1 = String (next 4-byte len + bytes), 2 = Float (next 8 bytes).
     fn high_key(&self, _layout: &Layout) -> Option<Constant> {
         let bytes = self.high_key_bytes()?;
-        if bytes.len() == 4 {
-            let mut buf = [0u8; 4];
-            buf.copy_from_slice(bytes);
-            return Some(Constant::Int(i32::from_le_bytes(buf)));
+        if bytes.len() < 4 {
+            return None;
         }
-        if bytes.len() >= 4 {
-            let len = u32::from_le_bytes(bytes[0..4].try_into().ok()?) as usize;
-            let sbytes = bytes.get(4..4 + len)?;
-            if let Ok(s) = std::str::from_utf8(sbytes) {
-                return Some(Constant::String(s.to_string()));
+        let tag = i32::from_le_bytes(bytes[0..4].try_into().ok()?);
+        match tag {
+            0 => Some(Constant::Int(i32::from_le_bytes(
+                bytes[4..8].try_into().ok()?,
+            ))),
+            2 => Some(Constant::Float(f64::from_bits(u64::from_le_bytes(
+                bytes[4..12].try_into().ok()?,
+            )))),
+            1 => {
+                let len = u32::from_le_bytes(bytes[4..8].try_into().ok()?) as usize;
+                let sbytes = bytes.get(8..8 + len)?;
+                std::str::from_utf8(sbytes)
+                    .ok()
+                    .map(|s| Constant::String(s.to_string()))
             }
+            _ => None,
         }
-        None
     }
 
     fn find_slot_before(&self, layout: &Layout, search_key: &Constant) -> Option<SlotId> {
@@ -6696,19 +6718,26 @@ impl<'a> BTreeInternalPage<'a> {
     #[cfg(test)]
     fn high_key(&self, _layout: &Layout) -> Option<Constant> {
         let bytes = self.high_key_bytes()?;
-        if bytes.len() == 4 {
-            let mut buf = [0u8; 4];
-            buf.copy_from_slice(bytes);
-            return Some(Constant::Int(i32::from_le_bytes(buf)));
+        if bytes.len() < 4 {
+            return None;
         }
-        if bytes.len() >= 4 {
-            let len = u32::from_le_bytes(bytes[0..4].try_into().ok()?) as usize;
-            let sbytes = bytes.get(4..4 + len)?;
-            if let Ok(s) = std::str::from_utf8(sbytes) {
-                return Some(Constant::String(s.to_string()));
+        let tag = i32::from_le_bytes(bytes[0..4].try_into().ok()?);
+        match tag {
+            0 => Some(Constant::Int(i32::from_le_bytes(
+                bytes[4..8].try_into().ok()?,
+            ))),
+            2 => Some(Constant::Float(f64::from_bits(u64::from_le_bytes(
+                bytes[4..12].try_into().ok()?,
+            )))),
+            1 => {
+                let len = u32::from_le_bytes(bytes[4..8].try_into().ok()?) as usize;
+                let sbytes = bytes.get(8..8 + len)?;
+                std::str::from_utf8(sbytes)
+                    .ok()
+                    .map(|s| Constant::String(s.to_string()))
             }
+            _ => None,
         }
-        None
     }
 
     fn slot_count(&self) -> usize {

--- a/src/page.rs
+++ b/src/page.rs
@@ -6170,19 +6170,16 @@ impl<'a> BTreeLeafPage<'a> {
     /// 0 = Int (next 4 bytes), 1 = String (next 4-byte len + bytes), 2 = Float (next 8 bytes).
     fn high_key(&self, _layout: &Layout) -> Option<Constant> {
         let bytes = self.high_key_bytes()?;
-        if bytes.len() < 4 {
-            return None;
-        }
-        let tag = i32::from_le_bytes(bytes[0..4].try_into().ok()?);
+        let tag = i32::from_le_bytes(bytes.get(0..4)?.try_into().ok()?);
         match tag {
             0 => Some(Constant::Int(i32::from_le_bytes(
-                bytes[4..8].try_into().ok()?,
+                bytes.get(4..8)?.try_into().ok()?,
             ))),
             2 => Some(Constant::Float(f64::from_bits(u64::from_le_bytes(
-                bytes[4..12].try_into().ok()?,
+                bytes.get(4..12)?.try_into().ok()?,
             )))),
             1 => {
-                let len = u32::from_le_bytes(bytes[4..8].try_into().ok()?) as usize;
+                let len = u32::from_le_bytes(bytes.get(4..8)?.try_into().ok()?) as usize;
                 let sbytes = bytes.get(8..8 + len)?;
                 std::str::from_utf8(sbytes)
                     .ok()
@@ -6718,19 +6715,16 @@ impl<'a> BTreeInternalPage<'a> {
     #[cfg(test)]
     fn high_key(&self, _layout: &Layout) -> Option<Constant> {
         let bytes = self.high_key_bytes()?;
-        if bytes.len() < 4 {
-            return None;
-        }
-        let tag = i32::from_le_bytes(bytes[0..4].try_into().ok()?);
+        let tag = i32::from_le_bytes(bytes.get(0..4)?.try_into().ok()?);
         match tag {
             0 => Some(Constant::Int(i32::from_le_bytes(
-                bytes[4..8].try_into().ok()?,
+                bytes.get(4..8)?.try_into().ok()?,
             ))),
             2 => Some(Constant::Float(f64::from_bits(u64::from_le_bytes(
-                bytes[4..12].try_into().ok()?,
+                bytes.get(4..12)?.try_into().ok()?,
             )))),
             1 => {
-                let len = u32::from_le_bytes(bytes[4..8].try_into().ok()?) as usize;
+                let len = u32::from_le_bytes(bytes.get(4..8)?.try_into().ok()?) as usize;
                 let sbytes = bytes.get(8..8 + len)?;
                 std::str::from_utf8(sbytes)
                     .ok()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -24,15 +24,12 @@ pub struct Parser<'a> {
 }
 
 impl<'a> Parser<'a> {
-    /// Creates a new Parser with the given SQL string
     pub fn new(string: &'a str) -> Self {
         Self {
             lexer: Lexer::new(string),
         }
     }
 
-    /// Parses a comma-separated list of field names
-    /// Returns: Vec<String> containing field names
     fn field_list(&mut self) -> Result<Vec<String>, ParserError> {
         let mut list = Vec::new();
         list.push(self.lexer.eat_identifier()?);
@@ -43,9 +40,8 @@ impl<'a> Parser<'a> {
         Ok(list)
     }
 
-    /// Returns true if the current token starts an aggregate function call.
-    /// These are not reserved keywords so any identifier matching a function
-    /// name is treated as an aggregate only in the SELECT context.
+    /// Aggregate function names (min, max, sum, count) are plain identifiers,
+    /// not reserved keywords, so they can still be used as column names elsewhere.
     fn is_aggregate_fn(&self) -> bool {
         self.lexer.match_identifier_value("min")
             || self.lexer.match_identifier_value("max")
@@ -53,8 +49,9 @@ impl<'a> Parser<'a> {
             || self.lexer.match_identifier_value("count")
     }
 
-    /// Parses one aggregate expression: `MIN(field)`, `MAX(field)`, `SUM(field)`,
-    /// or `COUNT(DISTINCT field)`.
+    /// `DISTINCT` is consumed as an identifier rather than a keyword so that
+    /// `count` is not forced to claim it as a reserved word, which would break
+    /// queries that use `distinct` as a column name outside aggregate context.
     fn parse_aggregate(&mut self) -> Result<AggregateSpec, ParserError> {
         if self.lexer.match_identifier_value("count") {
             self.lexer.eat_identifier()?;
@@ -94,10 +91,8 @@ impl<'a> Parser<'a> {
         Ok(AggregateSpec { op, field, alias })
     }
 
-    /// Parses the SELECT clause field list.
-    /// Returns: (output field names, aggregate specs).  For plain fields the
-    /// spec list is empty; for aggregate items the alias appears in the field list
-    /// so the final ProjectPlan can reference it by name.
+    /// Aggregate aliases (e.g. `max_price`) are inserted into the field list so
+    /// `ProjectPlan` can reference them by name without special-casing aggregates.
     fn select_list(&mut self) -> Result<(Vec<String>, Vec<AggregateSpec>), ParserError> {
         if self.lexer.match_delim('*') {
             self.lexer.eat_delim('*')?;
@@ -124,8 +119,6 @@ impl<'a> Parser<'a> {
         Ok((fields, aggregates))
     }
 
-    /// Parses the FROM clause table list
-    /// Returns: Vec<String> containing table names
     fn select_tables(&mut self) -> Result<Vec<String>, ParserError> {
         let mut list = Vec::new();
         list.push(self.lexer.eat_identifier()?);
@@ -136,7 +129,8 @@ impl<'a> Parser<'a> {
         Ok(list)
     }
 
-    /// Parses a constant value (string, integer, or float). Handles leading '-' for negatives.
+    /// Float is tried before int so that `3.14` produces `Float(3.14)` rather
+    /// than `Int(3)` followed by a stray `.14` that would fail the next token.
     fn constant(&mut self) -> Result<Constant, ParserError> {
         if self.lexer.match_string_constant() {
             return Ok(Constant::String(self.lexer.eat_string_constant()?));
@@ -153,8 +147,6 @@ impl<'a> Parser<'a> {
         Ok(Constant::Int(if negative { -v } else { v }))
     }
 
-    /// Parses a comma-separated list of constants
-    /// Returns: Vec<Constant> containing parsed values
     fn constants(&mut self) -> Result<Vec<Constant>, ParserError> {
         let mut const_list = Vec::new();
         const_list.push(self.constant()?);
@@ -165,8 +157,9 @@ impl<'a> Parser<'a> {
         Ok(const_list)
     }
 
-    /// Parses an expression (field name or constant)
-    /// Returns: Expression enum variant
+    /// Identifiers are checked first: in a WHERE clause `age > 30`, `age` is a
+    /// field name and `30` is a constant, so the identifier branch must win before
+    /// falling through to constant parsing.
     fn expression(&mut self) -> Result<Expression, ParserError> {
         if self.lexer.match_identifier() {
             return Ok(Expression::FieldName(self.lexer.eat_identifier()?));
@@ -174,8 +167,8 @@ impl<'a> Parser<'a> {
         Ok(Expression::Constant(self.constant()?))
     }
 
-    /// Parses a term (comparison between expressions)
-    /// Returns: Term struct containing lhs, rhs, and operator
+    /// The operator is matched directly on `current_token` (not via `eat_*`),
+    /// so `next_token()` must be called explicitly before parsing the RHS.
     fn term(&mut self) -> Result<Term, ParserError> {
         let lhs = self.expression()?;
         let op = match self.lexer.current_token {
@@ -194,8 +187,7 @@ impl<'a> Parser<'a> {
         Ok(Term::new_with_op(lhs, rhs, op))
     }
 
-    /// Parses multiple terms connected by AND
-    /// Returns: Vec<Term> containing all parsed terms
+    /// Dead code — predicate parsing was rewritten to use `parse_predicate`.
     fn _terms(&mut self) -> Result<Vec<Term>, ParserError> {
         let mut terms = Vec::new();
         terms.push(self.term()?);
@@ -207,8 +199,6 @@ impl<'a> Parser<'a> {
         Ok(terms)
     }
 
-    /// Parses a complete SELECT query
-    /// Returns: QueryData containing fields, tables, predicates, ORDER BY, and aggregates
     pub fn query(&mut self) -> Result<QueryData, ParserError> {
         self.lexer.eat_keyword("select")?;
         let (select_fields, aggregates) = self.select_list()?;
@@ -258,8 +248,6 @@ impl<'a> Parser<'a> {
         Ok(list)
     }
 
-    /// Parses any SQL command that modifies the database
-    /// Returns: SQLStatement enum variant
     pub fn update_command(&mut self) -> Result<SQLStatement, ParserError> {
         if self.lexer.match_keyword("insert") {
             Ok(SQLStatement::Insert(self.insert()?))
@@ -272,8 +260,6 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parses CREATE TABLE/VIEW/INDEX statements
-    /// Returns: SQLStatement enum variant
     fn create(&mut self) -> Result<SQLStatement, ParserError> {
         self.lexer.eat_keyword("create")?;
         if self.lexer.match_keyword("table") {
@@ -289,8 +275,9 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parses a single field definition (name and type)
-    /// Returns: Schema containing the field definition
+    /// `DECIMAL(p,s)` and `NUMERIC(p,s)` are accepted as aliases for `FLOAT`.
+    /// Precision and scale are parsed and discarded — the engine stores all
+    /// floating-point values as f64 regardless of declared precision.
     fn field_def(&mut self) -> Result<Schema, ParserError> {
         let field_name = self.lexer.eat_identifier()?;
         let mut schema = Schema::new();
@@ -325,8 +312,6 @@ impl<'a> Parser<'a> {
         Ok(schema)
     }
 
-    /// Parses multiple field definitions
-    /// Returns: Schema containing all field definitions
     fn field_defs(&mut self) -> Result<Schema, ParserError> {
         let mut schema = Schema::new();
         schema
@@ -341,8 +326,6 @@ impl<'a> Parser<'a> {
         Ok(schema)
     }
 
-    /// Parses CREATE TABLE statement
-    /// Returns: CreateTableData containing table name and schema
     fn create_table(&mut self) -> Result<CreateTableData, ParserError> {
         self.lexer.eat_keyword("table")?;
         let table_name = self.lexer.eat_identifier()?;
@@ -352,8 +335,6 @@ impl<'a> Parser<'a> {
         Ok(CreateTableData::new(table_name, field_defs))
     }
 
-    /// Parses CREATE VIEW statement
-    /// Returns: CreateViewData containing view name and query
     fn create_view(&mut self) -> Result<CreateViewData, ParserError> {
         self.lexer.eat_keyword("view")?;
         let view_name = self.lexer.eat_identifier()?;
@@ -362,8 +343,7 @@ impl<'a> Parser<'a> {
         Ok(CreateViewData::new(view_name, query_data))
     }
 
-    /// Parses CREATE INDEX statement
-    /// Returns: CreateIndexData containing index details
+    /// Only single-column indexes are supported; the grammar accepts exactly one field name.
     fn create_index(&mut self) -> Result<CreateIndexData, ParserError> {
         self.lexer.eat_keyword("index")?;
         let index_name = self.lexer.eat_identifier()?;
@@ -375,8 +355,6 @@ impl<'a> Parser<'a> {
         Ok(CreateIndexData::new(index_name, table_name, field))
     }
 
-    /// Parses INSERT statement
-    /// Returns: InsertData containing table name, fields, and values
     fn insert(&mut self) -> Result<InsertData, ParserError> {
         self.lexer.eat_keyword("insert")?;
         self.lexer.eat_keyword("into")?;
@@ -391,8 +369,6 @@ impl<'a> Parser<'a> {
         Ok(InsertData::new(table_name, field_list, constants))
     }
 
-    /// Parses DELETE statement
-    /// Returns: DeleteData containing table name and predicate
     fn delete(&mut self) -> Result<DeleteData, ParserError> {
         self.lexer.eat_keyword("delete")?;
         self.lexer.eat_keyword("from")?;
@@ -408,8 +384,6 @@ impl<'a> Parser<'a> {
         Ok(DeleteData::new(table_name, predicate))
     }
 
-    /// Parses UPDATE statement
-    /// Returns: ModifyData containing update details
     fn modify(&mut self) -> Result<ModifyData, ParserError> {
         self.lexer.eat_keyword("update")?;
         let table_name = self.lexer.eat_identifier()?;
@@ -430,7 +404,7 @@ impl<'a> Parser<'a> {
         ))
     }
 
-    /// Parses a full predicate with proper precedence: NOT > AND > OR.
+    /// Precedence: NOT binds tightest, then AND, then OR — standard SQL.
     fn parse_predicate(&mut self) -> Result<Predicate, ParserError> {
         self.parse_or()
     }
@@ -473,7 +447,6 @@ impl<'a> Parser<'a> {
         self.parse_primary_predicate()
     }
 
-    /// Parses a parenthesized predicate or a single comparison term
     fn parse_primary_predicate(&mut self) -> Result<Predicate, ParserError> {
         if self.lexer.match_delim('(') {
             self.lexer.eat_delim('(')?;
@@ -929,6 +902,7 @@ impl QueryData {
         }
     }
 
+    /// Not implemented — always panics. Exists as a placeholder.
     pub fn to_sql(&self) -> String {
         let mut sql = String::from("SELECT ");
         sql.push_str(&self.fields.join(", "));
@@ -961,7 +935,6 @@ impl<'a> Lexer<'a> {
     const SLASH: char = '/';
     const PERCENT: char = '%';
 
-    /// Creates a new Lexer with the given SQL string
     fn new(string: &'a str) -> Self {
         let keywords = [
             "select", "from", "where", "and", "or", "not", "insert", "into", "values", "delete",
@@ -977,7 +950,8 @@ impl<'a> Lexer<'a> {
         lexer
     }
 
-    /// Parses a string literal enclosed in single quotes
+    /// No escape sequence support: a literal `'` inside a string cannot be
+    /// represented. `''` (SQL standard doubling) is not handled either.
     fn parse_string(&mut self) -> Option<Token> {
         self.input.next(); //  consume the opening quote
         let mut string = String::new();
@@ -992,7 +966,8 @@ impl<'a> Lexer<'a> {
         Some(Token::StringConstant(string))
     }
 
-    /// Parses a numeric literal (integer or float).
+    /// Once a `.` is seen after digits, the token is committed to Float —
+    /// a trailing dot (e.g. `3.`) therefore produces `FloatConstant(3.0)`.
     fn parse_number(&mut self) -> Option<Token> {
         let mut number = String::new();
         while let Some(&c) = self.input.peek() {
@@ -1017,7 +992,7 @@ impl<'a> Lexer<'a> {
         Some(Token::IntConstant(number.parse().unwrap()))
     }
 
-    /// Parses an identifier or keyword
+    /// All identifiers and keywords are lowercased, making the lexer case-insensitive.
     fn parse_identifier_or_keyword(&mut self) -> Option<Token> {
         let mut string = String::new();
         while let Some(&c) = self.input.peek() {
@@ -1033,7 +1008,9 @@ impl<'a> Lexer<'a> {
         Some(Token::Identifier(string.to_lowercase()))
     }
 
-    /// Returns the next token from the input stream.
+    /// Whitespace and unrecognised characters are skipped by recursing — the
+    /// `_` arm consumes one character and calls `next_token` again rather than
+    /// returning an error, so the lexer is tolerant of unknown input.
     fn next_token(&mut self) -> Option<Token> {
         let c = self.input.peek().cloned()?;
         let token = match c {
@@ -1093,12 +1070,10 @@ impl<'a> Lexer<'a> {
         token
     }
 
-    /// Checks if current token matches the given delimiter
     fn match_delim(&self, ch: char) -> bool {
         matches!(self.current_token, Some(Token::Delimiter(d)) if d == ch)
     }
 
-    /// Consumes the current token if it matches the given delimiter
     fn eat_delim(&mut self, ch: char) -> Result<(), ParserError> {
         if !self.match_delim(ch) {
             return Err(ParserError::BadSyntax);
@@ -1107,12 +1082,10 @@ impl<'a> Lexer<'a> {
         Ok(())
     }
 
-    /// Checks if current token is an integer constant
     fn match_int_constant(&self) -> bool {
         matches!(self.current_token, Some(Token::IntConstant(_)))
     }
 
-    /// Consumes and returns the current integer constant
     fn eat_int_constant(&mut self) -> Result<i32, ParserError> {
         if !self.match_int_constant() {
             return Err(ParserError::BadSyntax);
@@ -1139,12 +1112,10 @@ impl<'a> Lexer<'a> {
         Ok(f)
     }
 
-    /// Checks if current token is a string constant
     fn match_string_constant(&self) -> bool {
         matches!(self.current_token, Some(Token::StringConstant(_)))
     }
 
-    /// Consumes and returns the current string constant
     fn eat_string_constant(&mut self) -> Result<String, ParserError> {
         if !self.match_string_constant() {
             return Err(ParserError::BadSyntax);
@@ -1156,17 +1127,14 @@ impl<'a> Lexer<'a> {
         Ok(s)
     }
 
-    /// Checks if current token is an identifier
     fn match_identifier(&self) -> bool {
         matches!(self.current_token, Some(Token::Identifier(_)))
     }
 
-    /// Checks if current token is an identifier with the given value.
     fn match_identifier_value(&self, value: &str) -> bool {
         matches!(&self.current_token, Some(Token::Identifier(id)) if id == value)
     }
 
-    /// Consumes and returns the current identifier
     fn eat_identifier(&mut self) -> Result<String, ParserError> {
         if !self.match_identifier() {
             return Err(ParserError::BadSyntax);
@@ -1178,12 +1146,10 @@ impl<'a> Lexer<'a> {
         Ok(id)
     }
 
-    /// Checks if current token matches the given keyword
     fn match_keyword(&self, keyword: &str) -> bool {
         matches!(&self.current_token, Some(Token::Keyword(token)) if token == keyword)
     }
 
-    /// Consumes and returns the current keyword if it matches
     fn eat_keyword(&mut self, keyword: &str) -> Result<String, ParserError> {
         if !self.match_keyword(keyword) {
             return Err(ParserError::BadSyntax);
@@ -1210,6 +1176,8 @@ pub enum Token {
     NotEqual,
 }
 
+/// `FloatConstant` uses `to_bits()` equality for the same reason as `Constant::PartialEq`:
+/// f64 doesn't implement `Eq`, so the derived impl is unavailable.
 impl PartialEq for Token {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -714,6 +714,59 @@ mod parser_tests {
             panic!("Expected Composite PredicateNode");
         }
     }
+
+    #[test]
+    fn test_float_constant_tokenization() {
+        let sql = "SELECT price FROM products WHERE price > 9.99";
+        let mut parser = Parser::new(sql);
+        let query = parser.query().unwrap();
+
+        if let PredicateNode::Term(term) = &query.predicate.root {
+            assert!(matches!(term.lhs, Expression::FieldName(ref name) if name == "price"));
+            assert!(matches!(
+                term.rhs,
+                Expression::Constant(Constant::Float(v)) if (v - 9.99).abs() < 1e-10
+            ));
+            assert!(matches!(term.comparison_op, ComparisonOp::GreaterThan));
+        } else {
+            panic!("Expected Term PredicateNode");
+        }
+    }
+
+    #[test]
+    fn test_negative_float_literal() {
+        let sql = "INSERT INTO t (x) VALUES (-3.14)";
+        let mut parser = Parser::new(sql);
+        let stmt = parser.update_command().unwrap();
+
+        if let SQLStatement::Insert(insert) = stmt {
+            assert_eq!(insert.values.len(), 1);
+            assert!(matches!(
+                insert.values[0],
+                Constant::Float(v) if (v - (-3.14)).abs() < 1e-10
+            ));
+        } else {
+            panic!("Expected InsertData");
+        }
+    }
+
+    #[test]
+    fn test_create_table_decimal_types() {
+        // DECIMAL(p,s) and NUMERIC(p,s) are aliases for float
+        let sql = "CREATE TABLE orders (id int, amount decimal(10,2), price numeric(8,4))";
+        let mut parser = Parser::new(sql);
+        let stmt = parser.update_command().unwrap();
+
+        if let SQLStatement::CreateTable(create_table) = stmt {
+            assert_eq!(create_table.table_name, "orders");
+            use crate::FieldType;
+            let schema = &create_table.schema;
+            assert_eq!(schema.info["amount"].field_type, FieldType::Float);
+            assert_eq!(schema.info["price"].field_type, FieldType::Float);
+        } else {
+            panic!("Expected CreateTableData");
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -248,6 +248,10 @@ impl<'a> Parser<'a> {
         Ok(list)
     }
 
+    /// CREATE has no explicit branch here because `create()` consumes the
+    /// `create` keyword itself, unlike INSERT/DELETE/UPDATE which are matched
+    /// above and then dispatched. Anything that isn't insert/delete/update
+    /// falls through and either succeeds as CREATE or returns BadSyntax.
     pub fn update_command(&mut self) -> Result<SQLStatement, ParserError> {
         if self.lexer.match_keyword("insert") {
             Ok(SQLStatement::Insert(self.insert()?))
@@ -260,6 +264,9 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// The `self.lexer.match_keyword("view")` and `match_keyword("index")` calls
+    /// in the view/index branches are no-ops — their return value is discarded.
+    /// The keyword is left unconsumed here and eaten by `create_view`/`create_index`.
     fn create(&mut self) -> Result<SQLStatement, ParserError> {
         self.lexer.eat_keyword("create")?;
         if self.lexer.match_keyword("table") {
@@ -355,6 +362,8 @@ impl<'a> Parser<'a> {
         Ok(CreateIndexData::new(index_name, table_name, field))
     }
 
+    /// Field count and value count are not validated to match; a mismatch
+    /// produces a silently malformed `InsertData` that will fail later at execution.
     fn insert(&mut self) -> Result<InsertData, ParserError> {
         self.lexer.eat_keyword("insert")?;
         self.lexer.eat_keyword("into")?;
@@ -369,6 +378,8 @@ impl<'a> Parser<'a> {
         Ok(InsertData::new(table_name, field_list, constants))
     }
 
+    /// WHERE is optional; omitting it produces an empty predicate that matches
+    /// every row, so the executor will delete the entire table.
     fn delete(&mut self) -> Result<DeleteData, ParserError> {
         self.lexer.eat_keyword("delete")?;
         self.lexer.eat_keyword("from")?;
@@ -384,6 +395,8 @@ impl<'a> Parser<'a> {
         Ok(DeleteData::new(table_name, predicate))
     }
 
+    /// WHERE is optional; omitting it produces an empty predicate that matches
+    /// every row, so the executor will update the entire table.
     fn modify(&mut self) -> Result<ModifyData, ParserError> {
         self.lexer.eat_keyword("update")?;
         let table_name = self.lexer.eat_identifier()?;
@@ -935,6 +948,8 @@ impl<'a> Lexer<'a> {
     const SLASH: char = '/';
     const PERCENT: char = '%';
 
+    /// `next_token()` is called at the end to prime `current_token`. Without it
+    /// every `match_*` call would return false because `current_token` starts as `None`.
     fn new(string: &'a str) -> Self {
         let keywords = [
             "select", "from", "where", "and", "or", "not", "insert", "into", "values", "delete",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -136,13 +136,21 @@ impl<'a> Parser<'a> {
         Ok(list)
     }
 
-    /// Parses a constant value (string or integer)
-    /// Returns: Constant enum variant
+    /// Parses a constant value (string, integer, or float). Handles leading '-' for negatives.
     fn constant(&mut self) -> Result<Constant, ParserError> {
         if self.lexer.match_string_constant() {
             return Ok(Constant::String(self.lexer.eat_string_constant()?));
         }
-        Ok(Constant::Int(self.lexer.eat_int_constant()?))
+        let negative = self.lexer.match_delim('-');
+        if negative {
+            self.lexer.eat_delim('-')?;
+        }
+        if self.lexer.match_float_constant() {
+            let v = self.lexer.eat_float_constant()?;
+            return Ok(Constant::Float(if negative { -v } else { v }));
+        }
+        let v = self.lexer.eat_int_constant()?;
+        Ok(Constant::Int(if negative { -v } else { v }))
     }
 
     /// Parses a comma-separated list of constants
@@ -289,6 +297,22 @@ impl<'a> Parser<'a> {
         if self.lexer.match_keyword("int") {
             self.lexer.eat_keyword("int")?;
             schema.add_int_field(&field_name);
+        } else if self.lexer.match_keyword("float")
+            || self.lexer.match_keyword("decimal")
+            || self.lexer.match_keyword("numeric")
+        {
+            self.lexer.next_token();
+            // Optional precision/scale: DECIMAL(p) or DECIMAL(p,s) — consume and ignore.
+            if self.lexer.match_delim('(') {
+                self.lexer.eat_delim('(')?;
+                self.lexer.eat_int_constant()?;
+                if self.lexer.match_delim(',') {
+                    self.lexer.eat_delim(',')?;
+                    self.lexer.eat_int_constant()?;
+                }
+                self.lexer.eat_delim(')')?;
+            }
+            schema.add_float_field(&field_name);
         } else if self.lexer.match_keyword("varchar") {
             self.lexer.eat_keyword("varchar")?;
             self.lexer.eat_delim('(')?;
@@ -888,8 +912,8 @@ impl<'a> Lexer<'a> {
     fn new(string: &'a str) -> Self {
         let keywords = [
             "select", "from", "where", "and", "or", "not", "insert", "into", "values", "delete",
-            "update", "set", "create", "table", "int", "varchar", "view", "as", "index", "on",
-            "order", "by", "asc", "desc",
+            "update", "set", "create", "table", "int", "varchar", "float", "decimal", "numeric",
+            "view", "as", "index", "on", "order", "by", "asc", "desc",
         ];
         let mut lexer = Self {
             input: string.chars().peekable(),
@@ -915,7 +939,7 @@ impl<'a> Lexer<'a> {
         Some(Token::StringConstant(string))
     }
 
-    /// Parses a numeric literal
+    /// Parses a numeric literal (integer or float).
     fn parse_number(&mut self) -> Option<Token> {
         let mut number = String::new();
         while let Some(&c) = self.input.peek() {
@@ -924,6 +948,18 @@ impl<'a> Lexer<'a> {
             }
             number.push(c);
             self.input.next();
+        }
+        if self.input.peek() == Some(&'.') {
+            number.push('.');
+            self.input.next();
+            while let Some(&c) = self.input.peek() {
+                if !c.is_ascii_digit() {
+                    break;
+                }
+                number.push(c);
+                self.input.next();
+            }
+            return Some(Token::FloatConstant(number.parse().unwrap()));
         }
         Some(Token::IntConstant(number.parse().unwrap()))
     }
@@ -1035,6 +1071,21 @@ impl<'a> Lexer<'a> {
         Ok(i)
     }
 
+    fn match_float_constant(&self) -> bool {
+        matches!(self.current_token, Some(Token::FloatConstant(_)))
+    }
+
+    fn eat_float_constant(&mut self) -> Result<f64, ParserError> {
+        if !self.match_float_constant() {
+            return Err(ParserError::BadSyntax);
+        }
+        let Some(Token::FloatConstant(f)) = self.current_token else {
+            return Err(ParserError::BadSyntax);
+        };
+        self.next_token();
+        Ok(f)
+    }
+
     /// Checks if current token is a string constant
     fn match_string_constant(&self) -> bool {
         matches!(self.current_token, Some(Token::StringConstant(_)))
@@ -1092,11 +1143,12 @@ impl<'a> Lexer<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub enum Token {
     Keyword(String),
     Identifier(String),
     IntConstant(i32),
+    FloatConstant(f64),
     StringConstant(String),
     Delimiter(char),
     // Multi-character operators
@@ -1104,6 +1156,25 @@ pub enum Token {
     GreaterOrEqual,
     NotEqual,
 }
+
+impl PartialEq for Token {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Token::Keyword(a), Token::Keyword(b)) => a == b,
+            (Token::Identifier(a), Token::Identifier(b)) => a == b,
+            (Token::IntConstant(a), Token::IntConstant(b)) => a == b,
+            (Token::FloatConstant(a), Token::FloatConstant(b)) => a.to_bits() == b.to_bits(),
+            (Token::StringConstant(a), Token::StringConstant(b)) => a == b,
+            (Token::Delimiter(a), Token::Delimiter(b)) => a == b,
+            (Token::LessOrEqual, Token::LessOrEqual) => true,
+            (Token::GreaterOrEqual, Token::GreaterOrEqual) => true,
+            (Token::NotEqual, Token::NotEqual) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Token {}
 
 #[cfg(test)]
 mod lexer_tests {


### PR DESCRIPTION
Part of #109 (TPC-C tracking). Closes #112.

## What changed

`FieldType::Float` (stored as 8-byte IEEE 754 f64, little-endian) is now a first-class type throughout the engine. The change touches storage, aggregates, the parser, and B-tree pages.

**Storage and layout.** `Schema::add_float_field` registers an 8-byte field. `Layout` computes offsets, max-encoded-size, and heap-tuple encode/decode for float fields. `RecordPage` gains `get_float`/`set_float`. `TableScan` and `ChunkScan` route through those in their `get_value`/`set_value` dispatch.

**B-tree pages.** `BTreeLeafEntry` and `BTreeInternalEntry` encode and decode float keys using the field layout's type tag, the same way they already handle int and string. The high-key byte encoding is upgraded from a length-heuristic (4 bytes = Int, otherwise String) to an explicit 4-byte little-endian type tag (0 = Int, 1 = String, 2 = Float), so all three types are unambiguous. Both `high_key()` decoders and `TryInto<Vec<u8>>` for `Constant` are updated consistently.

**WAL.** BTree leaf-delete and internal-delete log records serialize float keys with type tag 2 followed by 8 raw f64 bits, matching the existing int (tag 0) and string (tag 1) convention.

**Aggregates.** `SUM` accumulates as `f64` internally. It emits `Constant::Float` when the source field is float, and `Constant::Int` for integer fields (the existing behavior). `MIN`/`MAX` propagate the float type through the output schema and empty-source defaults.

**Parser.** `FLOAT`, `DECIMAL`, and `NUMERIC` are recognized in `CREATE TABLE` field definitions; optional `(precision)` or `(precision, scale)` qualifiers are consumed and ignored. Numeric literals containing a `.` lex as `Token::FloatConstant(f64)`. A leading `-` is handled in `constant()` so negative float and integer literals parse correctly.

**`Constant` trait impls.** `Hash`, `Eq`, and `Ord` are implemented manually using `f64::to_bits()` so `Constant::Float` can participate in `HashSet<Constant>` (used by `COUNT(DISTINCT)`) and sorted scans.

## Out of scope

The default for an omitted float column in INSERT is `0.0`; NULL support is not added here.